### PR TITLE
9C-242: Adds Flyway SBT plugin into the project

### DIFF
--- a/modules/api/src/main/resources/db/migration/V0__SampleFile.sql
+++ b/modules/api/src/main/resources/db/migration/V0__SampleFile.sql
@@ -1,0 +1,33 @@
+--Flyway is an open-source database migration tool. It strongly favors simplicity and convention over configuration.
+--
+--It is based around just 6 basic commands: Migrate, Clean, Info, Validate, Baseline and Repair.
+--
+--Migrations can be written in SQL (database-specific syntax (such as PL/SQL, T-SQL, ...) is supported) or Java (for advanced data transformations or dealing with LOBs).
+
+--Versions
+--Each migration must have a unique version and a description.
+--
+--A version must have the following structure:
+--
+--One or more numeric parts
+--Separated by a dot (.) or an underscore (_)
+--Underscores are replaced by dots at runtime
+--Leading zeroes are ignored in each part
+--Examples of valid versions:
+--
+--1
+--001
+--5.2
+--5_2 (5.2 at runtime)
+--1.2.3.4.5.6.7.8.9
+--205.68
+--20130115113556
+--2013.1.15.11.35.56
+--2013.01.15.11.35.56
+
+--A example of a migration field could be:
+
+--create table PERSON (
+--    ID int not null,
+--    NAME varchar(100) not null
+--);

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,11 +1,13 @@
 import sbt.Keys._
 import sbt._
 import spray.revolver.RevolverPlugin
+import org.flywaydb.sbt.FlywayPlugin._
 
 trait Settings {
   this: Build =>
 
   lazy val projectSettings: Seq[Def.Setting[_]] = Seq(
+    run <<= run in Runtime dependsOn flywayMigrate,
     scalaVersion := Versions.scala,
     organization := "com.fortysevendeg",
     organizationName := "47 Degrees",
@@ -24,10 +26,14 @@ trait Settings {
       Classpaths.typesafeReleases,
       Resolver.bintrayRepo("scalaz", "releases"),
       DefaultMavenRepository,
-      "Sonatype Snapshots"  at "https://oss.sonatype.org/content/repositories/snapshots"
+      "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
     ),
     doc in Compile <<= target.map(_ / "none")
-  )
+  ) ++ Seq(flywaySettings: _*) ++ Seq(
+    flywayDriver := sys.props.getOrElse("db.driver", default = ""),
+    flywayUrl := sys.props.getOrElse("db.url", default = ""),
+    flywayUser := sys.props.getOrElse("db.user", default = ""),
+    flywayPassword := sys.props.getOrElse("db.password", default = ""))
 
   lazy val apiSettings = projectSettings ++ Seq(
     publishArtifact in(Test, packageBin) := false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,13 @@
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
-
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
 
+resolvers += "Flyway" at "http://flywaydb.org/repo"
+
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
+
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
 
 addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.2.1")
+
+addSbtPlugin("org.flywaydb" % "flyway-sbt" % "3.2.1")


### PR DESCRIPTION
This PR integrates [Flyway](http://flywaydb.org/) into the project to manage the database schema evolutions.

I have added a dependency to the `run` task in order to execute `flywayMigrate` each time the Spray app is run. This task checks if all the migration files has been applied to the database and otherwise it updates the database schema.

In order to avoid to have sensitive info in the `build.sbt` file, I use this command: `sys.props.getOrElse("db.driver", default = "")` and the info is passed when `sbt` is started in this way:

```
sbt -Ddb.driver=org.postgresql.Driver
```

I have created another ticket in order to try to use the [Typesafe config library](https://github.com/typesafehub/config) and get the database connection info from a config file instead of passing as command-line parameters.

@raulraja @noelmarkham Could you take a look when you have a chance?
