### PR TITLE
9C-243: Adds SettingKey to read the database info

### DIFF
--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -1,0 +1,20 @@
+akka {
+  loglevel = INFO
+}
+
+spray.can.server {
+  request-timeout = 1s
+}
+
+db {
+  default {
+    driver = "org.postgresql.Driver"
+    driver = ${?DB_DEFAULT_DRIVER}
+    url = ""
+    url = ${?DB_DEFAULT_URL}
+    user = ""
+    user = ${?DB_DEFAULT_USER}
+    password = ""
+    password = ${?DB_DEFAULT_PASSWORD}
+  }
+}

--- a/project/FlywayConfig.scala
+++ b/project/FlywayConfig.scala
@@ -1,0 +1,35 @@
+import com.typesafe.config._
+import sbt.Keys._
+import sbt._
+
+object FlywayConfig {
+
+  case class DatabaseConfig(driver: String, url: String, user: String, password: String)
+
+  class CustomConfig(fileName: File) {
+
+    val config = ConfigFactory.parseFile(fileName).resolve
+
+    def envOrElseConfig(name: String): String = {
+      sys.props.getOrElse(
+        key = name,
+        default = config.getString(name)
+      )
+    }
+  }
+
+  lazy val databaseConfig = settingKey[DatabaseConfig]("The database config to use in Flyway")
+
+  lazy val databaseConfigDef: Def.Initialize[DatabaseConfig] =
+    Def.setting[DatabaseConfig] {
+      val config = new CustomConfig((resourceDirectory in Compile).value / "application.conf")
+      val prefix = "db.default"
+
+      DatabaseConfig(
+        driver = config.envOrElseConfig(s"$prefix.driver"),
+        url = config.envOrElseConfig(s"$prefix.url"),
+        user = config.envOrElseConfig(s"$prefix.user"),
+        password = config.envOrElseConfig(s"$prefix.password")
+      )
+    }
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,13 +1,13 @@
+import FlywayConfig._
+import org.flywaydb.sbt.FlywayPlugin._
 import sbt.Keys._
 import sbt._
 import spray.revolver.RevolverPlugin
-import org.flywaydb.sbt.FlywayPlugin._
 
 trait Settings {
   this: Build =>
 
   lazy val projectSettings: Seq[Def.Setting[_]] = Seq(
-    run <<= run in Runtime dependsOn flywayMigrate,
     scalaVersion := Versions.scala,
     organization := "com.fortysevendeg",
     organizationName := "47 Degrees",
@@ -29,13 +29,17 @@ trait Settings {
       "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
     ),
     doc in Compile <<= target.map(_ / "none")
-  ) ++ Seq(flywaySettings: _*) ++ Seq(
-    flywayDriver := sys.props.getOrElse("db.driver", default = ""),
-    flywayUrl := sys.props.getOrElse("db.url", default = ""),
-    flywayUser := sys.props.getOrElse("db.user", default = ""),
-    flywayPassword := sys.props.getOrElse("db.password", default = ""))
+  )
 
   lazy val apiSettings = projectSettings ++ Seq(
+    databaseConfig := databaseConfigDef.value,
+    run <<= run in Runtime dependsOn flywayMigrate,
     publishArtifact in(Test, packageBin) := false
-  ) ++ RevolverPlugin.settings
+  ) ++ RevolverPlugin.settings ++ Seq(flywaySettings: _*) ++ Seq(
+    flywayDriver := databaseConfig.value.driver,
+    flywayUrl := databaseConfig.value.url,
+    flywayUser := databaseConfig.value.user,
+    flywayPassword := databaseConfig.value.password
+  )
+
 }


### PR DESCRIPTION
This PR adds a `SettingKey` in SBT to get the database connection info from a config file using the [Typesafe config](https://github.com/typesafehub/config) library.

Using this `SettingKey` we can set the database connection info in three possible ways:
1. Passing the values to the `sbt` command: `sbt -Ddb.default.url=...`
2. Setting an environment variable: `export DB_DEFAULT_URL=...`
3. Writing the database info into the `application.conf`

@noelmarkham @juanpedromoreno Can you take a look please? Thanks
