### PR TITLE
9C-248: Update endpoint to update device

### DIFF
--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/JsonFormats.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/JsonFormats.scala
@@ -1,6 +1,6 @@
 package com.fortysevendeg.ninecards.api
 
-import com.fortysevendeg.ninecards.api.messages.DevicesMessages._
+import com.fortysevendeg.ninecards.api.messages.InstallationsMessages._
 import com.fortysevendeg.ninecards.processes.messages._
 import com.fortysevendeg.ninecards.processes.domain._
 import spray.httpx.SprayJsonSupport
@@ -16,7 +16,7 @@ trait JsonFormats
 
   implicit val addUserRequest = jsonFormat1(AddUserRequest)
 
-  implicit val updateDeviceRequestFormat = jsonFormat1(ApiUpdateDeviceRequest)
+  implicit val updateInstallationRequestFormat = jsonFormat1(ApiUpdateInstallationRequest)
 
-  implicit val updateDeviceResponseFormat = jsonFormat2(ApiUpdateDeviceResponse)
+  implicit val updateInstallationResponseFormat = jsonFormat2(ApiUpdateInstallationResponse)
 }

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsApi.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsApi.scala
@@ -4,7 +4,7 @@ import akka.actor.Actor
 import com.fortysevendeg.ninecards.api.FreeUtils._
 import com.fortysevendeg.ninecards.api.NineCardsApiHeaderCommons._
 import com.fortysevendeg.ninecards.api.converters.Converters._
-import com.fortysevendeg.ninecards.api.messages.DevicesMessages._
+import com.fortysevendeg.ninecards.api.messages.InstallationsMessages._
 import com.fortysevendeg.ninecards.processes.NineCardsServices.NineCardsServices
 import com.fortysevendeg.ninecards.processes.domain._
 import com.fortysevendeg.ninecards.processes.messages._
@@ -34,7 +34,7 @@ trait NineCardsApi
 
   def nineCardsApiRoute(implicit appProcesses: AppProcesses[NineCardsServices], userProcesses: UserProcesses[NineCardsServices]): Route =
     userApiRoute() ~
-      devicesApiRoute() ~
+      installationsApiRoute() ~
       appsApiRoute() ~
       swaggerApiRoute
 
@@ -56,21 +56,21 @@ trait NineCardsApi
       }
     }
 
-  private[this] def devicesApiRoute()(implicit userProcesses: UserProcesses[NineCardsServices]) =
-    pathPrefix("devices") {
+  private[this] def installationsApiRoute()(implicit userProcesses: UserProcesses[NineCardsServices]) =
+    pathPrefix("installations") {
       pathEndOrSingleSlash {
         requestFullHeaders {
           (appId, apiKey, sessionToken, androidId, marketLocalization) =>
             put {
-              entity(as[ApiUpdateDeviceRequest]) {
+              entity(as[ApiUpdateInstallationRequest]) {
                 request =>
                   /* TODO: The userId should be fetched after authorizing the user through the sessionToken - Issue 266 */
                   implicit val userId = 123456789l
                   implicit val deviceAndroidId = androidId
 
                   complete {
-                    val result: Task[ApiUpdateDeviceResponse] =
-                      userProcesses.updateDevice(request) map toApiUpdateDeviceResponse
+                    val result: Task[ApiUpdateInstallationResponse] =
+                      userProcesses.updateInstallation(request) map toApiUpdateInstallationResponse
                     result
                   }
               }

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/converters/Converters.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/converters/Converters.scala
@@ -1,22 +1,23 @@
 package com.fortysevendeg.ninecards.api.converters
 
-import com.fortysevendeg.ninecards.api.messages.DevicesMessages._
-import com.fortysevendeg.ninecards.processes.messages.DevicesMessages._
+import com.fortysevendeg.ninecards.api.messages.InstallationsMessages._
+import com.fortysevendeg.ninecards.processes.messages.InstallationsMessages._
 
 import scala.language.implicitConversions
 
 object Converters {
 
-  implicit def toUpdateDeviceRequest(
-    request: ApiUpdateDeviceRequest)(implicit userId: Long, androidId: String): UpdateDeviceRequest =
-    UpdateDeviceRequest(
+  implicit def toUpdateInstallationRequest(
+    request: ApiUpdateInstallationRequest)(
+    implicit userId: Long, androidId: String): UpdateInstallationRequest =
+    UpdateInstallationRequest(
       userId = userId,
       androidId = androidId,
       deviceToken = request.deviceToken)
 
-  implicit def toApiUpdateDeviceResponse(
-    response: UpdateDeviceResponse): ApiUpdateDeviceResponse =
-    ApiUpdateDeviceResponse(
+  implicit def toApiUpdateInstallationResponse(
+    response: UpdateInstallationResponse): ApiUpdateInstallationResponse =
+    ApiUpdateInstallationResponse(
       androidId = response.androidId,
       deviceToken = response.deviceToken)
 

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/messages/DevicesMessages.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/messages/DevicesMessages.scala
@@ -1,8 +1,0 @@
-package com.fortysevendeg.ninecards.api.messages
-
-object DevicesMessages {
-
-  case class ApiUpdateDeviceRequest(deviceToken: Option[String])
-
-  case class ApiUpdateDeviceResponse(androidId: String, deviceToken: Option[String])
-}

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/messages/InstallationsMessages.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/messages/InstallationsMessages.scala
@@ -1,0 +1,8 @@
+package com.fortysevendeg.ninecards.api.messages
+
+object InstallationsMessages {
+
+  case class ApiUpdateInstallationRequest(deviceToken: Option[String])
+
+  case class ApiUpdateInstallationResponse(androidId: String, deviceToken: Option[String])
+}

--- a/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/UserProcesses.scala
+++ b/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/UserProcesses.scala
@@ -6,7 +6,7 @@ import cats.free.Free
 import com.fortysevendeg.ninecards.processes.converters.Converters._
 import com.fortysevendeg.ninecards.processes.domain.User
 import com.fortysevendeg.ninecards.processes.messages.AddUserRequest
-import com.fortysevendeg.ninecards.processes.messages.DevicesMessages.{UpdateDeviceRequest, UpdateDeviceResponse}
+import com.fortysevendeg.ninecards.processes.messages.InstallationsMessages.{UpdateInstallationRequest, UpdateInstallationResponse}
 import com.fortysevendeg.ninecards.services.free.algebra.Users.UserServices
 import com.fortysevendeg.ninecards.services.free.domain.{User => UserAppServices}
 
@@ -30,11 +30,11 @@ class UserProcesses[F[_]](
     UserAppServices(
       sessionToken = Option(UUID.randomUUID().toString))
 
-  def updateDevice(request: UpdateDeviceRequest): Free[F, UpdateDeviceResponse] =
-    userServices.updateDevice(
+  def updateInstallation(request: UpdateInstallationRequest): Free[F, UpdateInstallationResponse] =
+    userServices.updateInstallation(
       userId = request.userId,
       androidId = request.androidId,
-      deviceToken = request.deviceToken) map toUpdateDeviceResponse
+      deviceToken = request.deviceToken) map toUpdateInstallationResponse
 
 }
 

--- a/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/converters/Converters.scala
+++ b/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/converters/Converters.scala
@@ -1,9 +1,9 @@
 package com.fortysevendeg.ninecards.processes.converters
 
 import com.fortysevendeg.ninecards.processes.domain._
-import com.fortysevendeg.ninecards.processes.messages.DevicesMessages.UpdateDeviceResponse
+import com.fortysevendeg.ninecards.processes.messages.InstallationsMessages._
 import com.fortysevendeg.ninecards.services.free.domain.{
-Device => DeviceServices,
+Installation => InstallationServices,
 GooglePlayApp => GooglePlayAppServices,
 User => UserAppServices
 }
@@ -32,9 +32,9 @@ object Converters {
       email = app.email,
       sessionToken = app.sessionToken)
 
-  def toUpdateDeviceResponse(device: DeviceServices): UpdateDeviceResponse =
-    UpdateDeviceResponse(
-      androidId = device.androidId,
-      deviceToken = device.deviceToken)
+  def toUpdateInstallationResponse(installation: InstallationServices): UpdateInstallationResponse =
+    UpdateInstallationResponse(
+      androidId = installation.androidId,
+      deviceToken = installation.deviceToken)
 
 }

--- a/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/messages/DevicesMessages.scala
+++ b/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/messages/DevicesMessages.scala
@@ -1,8 +1,0 @@
-package com.fortysevendeg.ninecards.processes.messages
-
-object DevicesMessages {
-
-  case class UpdateDeviceRequest(userId: Long, androidId: String, deviceToken: Option[String])
-
-  case class UpdateDeviceResponse(androidId: String, deviceToken: Option[String])
-}

--- a/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/messages/InstallationsMessages.scala
+++ b/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/messages/InstallationsMessages.scala
@@ -1,0 +1,8 @@
+package com.fortysevendeg.ninecards.processes.messages
+
+object InstallationsMessages {
+
+  case class UpdateInstallationRequest(userId: Long, androidId: String, deviceToken: Option[String])
+
+  case class UpdateInstallationResponse(androidId: String, deviceToken: Option[String])
+}

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/algebra/Users.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/algebra/Users.scala
@@ -1,7 +1,7 @@
 package com.fortysevendeg.ninecards.services.free.algebra
 
 import cats.free.{Free, Inject}
-import com.fortysevendeg.ninecards.services.free.domain.{Device, User}
+import com.fortysevendeg.ninecards.services.free.domain.{Installation, User}
 
 import scala.language.higherKinds
 
@@ -13,15 +13,15 @@ object Users {
 
   case class GetUserByEmail(email: String) extends UserOps[Option[User]]
 
-  case class CreateDevice(
+  case class CreateInstallation(
     userId: Long,
     androidId: String,
-    deviceToken: Option[String]) extends UserOps[Device]
+    deviceToken: Option[String]) extends UserOps[Installation]
 
-  case class UpdateDevice(
+  case class UpdateInstallation(
     userId: Long,
     androidId: String,
-    deviceToken: Option[String]) extends UserOps[Device]
+    deviceToken: Option[String]) extends UserOps[Installation]
 
   class UserServices[F[_]](implicit I: Inject[UserOps, F]) {
 
@@ -29,17 +29,17 @@ object Users {
 
     def getUserByEmail(email: String): Free[F, Option[User]] = Free.inject[UserOps, F](GetUserByEmail(email))
 
-    def createDevice(
+    def createInstallation(
       userId: Long,
       androidId: String,
-      deviceToken: Option[String]): Free[F, Device] =
-      Free.inject[UserOps, F](CreateDevice(userId, androidId, deviceToken))
+      deviceToken: Option[String]): Free[F, Installation] =
+      Free.inject[UserOps, F](CreateInstallation(userId, androidId, deviceToken))
 
-    def updateDevice(
+    def updateInstallation(
       userId: Long,
       androidId: String,
-      deviceToken: Option[String]): Free[F, Device] =
-      Free.inject[UserOps, F](UpdateDevice(userId, androidId, deviceToken))
+      deviceToken: Option[String]): Free[F, Installation] =
+      Free.inject[UserOps, F](UpdateInstallation(userId, androidId, deviceToken))
 
   }
 

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/domain/User.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/domain/User.scala
@@ -5,7 +5,7 @@ case class User(
   email: Option[String] = None,
   sessionToken: Option[String] = None)
 
-case class Device(
+case class Installation(
   id: Long,
   userId: Long,
   deviceToken: Option[String] = None,

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/interpreter/Interpreters.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/interpreter/Interpreters.scala
@@ -97,13 +97,13 @@ object Interpreters {
         Task {
           userPersistenceImpl.addUser(user)
         }
-      case CreateDevice(userId: Long, androidId: String, deviceToken: Option[String]) =>
+      case CreateInstallation(userId: Long, androidId: String, deviceToken: Option[String]) =>
         Task {
-          userPersistenceImpl.createDevice(userId, androidId, deviceToken)
+          userPersistenceImpl.createInstallation(userId, androidId, deviceToken)
         }
-      case UpdateDevice(userId: Long, androidId: String, deviceToken: Option[String]) =>
+      case UpdateInstallation(userId: Long, androidId: String, deviceToken: Option[String]) =>
         Task {
-          userPersistenceImpl.updateDevice(userId, androidId, deviceToken)
+          userPersistenceImpl.updateInstallation(userId, androidId, deviceToken)
         }
     }
   }

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/interpreter/impl/UserPersistenceImpl.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/interpreter/impl/UserPersistenceImpl.scala
@@ -14,15 +14,15 @@ class UserPersistenceImpl {
       )
     )
 
-  def createDevice(userId: Long, androidId: String, deviceToken: Option[String]) =
-    Device(
+  def createInstallation(userId: Long, androidId: String, deviceToken: Option[String]) =
+    Installation(
       id = 12345678l,
       userId = userId,
       androidId = androidId,
       deviceToken = deviceToken)
 
-  def updateDevice(userId: Long, androidId: String, deviceToken: Option[String]) =
-    Device(
+  def updateInstallation(userId: Long, androidId: String, deviceToken: Option[String]) =
+    Installation(
       id = 12345678l,
       userId = userId,
       androidId = androidId,


### PR DESCRIPTION
This PR update the endpoint that allows to update an existing installation for an user in NineCards server.

This PR closes the issue https://github.com/47deg/nine-cards-v2/issues/248

The code was reviewed in other PR that was created against a wrong base branch: https://github.com/47deg/nine-cards-backend/pull/21
