### PR TITLE
9C-335: Removing warning messages on compilation

### DIFF
--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsApi.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsApi.scala
@@ -14,7 +14,6 @@ import spray.httpx.SprayJsonSupport
 import spray.routing._
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.language.{higherKinds, implicitConversions}
 
 class NineCardsApiActor
   extends Actor

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsAuthenticator.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsAuthenticator.scala
@@ -14,7 +14,6 @@ import spray.routing.directives._
 import spray.routing.{AuthenticationFailedRejection, Directive, Directive0}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.language.implicitConversions
 import scalaz.concurrent.Task
 import scalaz.{-\/, \/-}
 

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/converters/Converters.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/converters/Converters.scala
@@ -6,8 +6,6 @@ import com.fortysevendeg.ninecards.api.messages.UserMessages._
 import com.fortysevendeg.ninecards.processes.messages.InstallationsMessages._
 import com.fortysevendeg.ninecards.processes.messages.UserMessages._
 
-import scala.language.implicitConversions
-
 object Converters {
 
   implicit def toLoginRequest(

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/utils/FreeUtils.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/utils/FreeUtils.scala
@@ -4,8 +4,6 @@ import cats.free.Free
 import cats.{Monad, ~>}
 import com.fortysevendeg.ninecards.processes.NineCardsServices
 
-import scala.language.{higherKinds, implicitConversions}
-
 object FreeUtils {
 
   implicit val interpreters = NineCardsServices.interpreters

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/utils/TaskUtils.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/utils/TaskUtils.scala
@@ -5,7 +5,6 @@ import cats.free.Free
 import shapeless.Lazy
 import spray.httpx.marshalling.ToResponseMarshaller
 
-import scala.language.{higherKinds, implicitConversions}
 import scalaz.concurrent.Task
 
 object TaskUtils {

--- a/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/AppProcesses.scala
+++ b/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/AppProcesses.scala
@@ -6,8 +6,6 @@ import com.fortysevendeg.ninecards.processes.domain.GooglePlayApp
 import com.fortysevendeg.ninecards.services.free.algebra.AppGooglePlay.AppGooglePlayServices
 import com.fortysevendeg.ninecards.services.free.algebra.AppPersistence.AppPersistenceServices
 
-import scala.language.higherKinds
-
 class AppProcesses[F[_]](
   implicit appPersistenceServices: AppPersistenceServices[F],
   appGooglePlayServices: AppGooglePlayServices[F]) {

--- a/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/UserProcesses.scala
+++ b/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/UserProcesses.scala
@@ -12,7 +12,6 @@ import com.fortysevendeg.ninecards.services.free.domain._
 import com.fortysevendeg.ninecards.services.persistence.{UserPersistenceServices, _}
 import doobie.imports._
 
-import scala.language.higherKinds
 import scalaz.Scalaz._
 
 class UserProcesses[F[_]](

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/common/TaskOps.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/common/TaskOps.scala
@@ -4,7 +4,6 @@ import cats.free.Free
 import com.fortysevendeg.ninecards.services.free.algebra.DBResult.DBOps
 import com.fortysevendeg.ninecards.services.persistence.PersistenceExceptions.PersistenceException
 
-import scala.language.{higherKinds, implicitConversions}
 import scalaz.concurrent.Task
 import scalaz.{-\/, \/-}
 

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/algebra/AppGooglePlay.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/algebra/AppGooglePlay.scala
@@ -3,8 +3,6 @@ package com.fortysevendeg.ninecards.services.free.algebra
 import cats.free.{Free, Inject}
 import com.fortysevendeg.ninecards.services.free.domain.CategorizeResponse
 
-import scala.language.higherKinds
-
 object AppGooglePlay {
 
   sealed trait AppGooglePlayOps[A]

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/algebra/AppPersistence.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/algebra/AppPersistence.scala
@@ -3,8 +3,6 @@ package com.fortysevendeg.ninecards.services.free.algebra
 import cats.free.{Free, Inject}
 import com.fortysevendeg.ninecards.services.free.domain.CategorizeResponse
 
-import scala.language.higherKinds
-
 object AppPersistence {
 
   sealed trait AppPersistenceOps[A]

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/algebra/DBResult.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/algebra/DBResult.scala
@@ -2,8 +2,6 @@ package com.fortysevendeg.ninecards.services.free.algebra
 
 import cats.free.{Free, Inject}
 
-import scala.language.higherKinds
-
 object DBResult {
 
   sealed trait DBResult[A]

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/algebra/SharedCollections.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/algebra/SharedCollections.scala
@@ -3,8 +3,6 @@ package com.fortysevendeg.ninecards.services.free.algebra
 import cats.free.{Free, Inject}
 import com.fortysevendeg.ninecards.services.free.domain.{SharedCollection, SharedCollectionSubscription}
 
-import scala.language.higherKinds
-
 object SharedCollections {
 
   sealed trait SharedCollectionOps[A]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ trait Dependencies {
   val specs2Mockito = "org.specs2" %% "specs2-mock" % Versions.specs2
   val scalaz = "org.scalaz" %% "scalaz-core" % Versions.scalaz
   val scalazConcurrent = "org.scalaz" %% "scalaz-concurrent" % Versions.scalaz
+  val jodaConvert = "org.joda" % "joda-convert" % Versions.jodaConvert
   val jodaTime = "joda-time" % "joda-time" % Versions.jodaTime
   val doobieCore = "org.tpolecat" %% "doobie-core" % Versions.doobie
   val doobieH2 = "org.tpolecat" %% "doobie-contrib-h2" % Versions.doobie
@@ -48,6 +49,7 @@ trait Dependencies {
     scalazConcurrent))
 
   val servicesDeps = Seq(libraryDependencies ++= baseDepts ++ Seq(
+    jodaConvert,
     jodaTime,
     cats,
     doobieCore exclude("org.scalaz", "*"),

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -15,7 +15,7 @@ trait Settings {
     organizationHomepage := Some(new URL("http://47deg.com")),
     version := Versions.buildVersion,
     conflictWarning := ConflictWarning.disable,
-    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature"),
+    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:higherKinds", "-language:implicitConversions"),
     javaOptions in Test ++= Seq("-XX:MaxPermSize=128m", "-Xms512m", "-Xmx512m"),
     sbt.Keys.fork in Test := false,
     publishMavenStyle := true,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,6 +8,7 @@ object Versions {
   val cats = "0.4.0"
   val doobie = "0.2.4-SNAPSHOT"
   val flywaydb = "4.0"
+  val jodaConvert = "1.8.1"
   val jodaTime = "2.9.2"
   val scala = "2.11.7"
   val scalacheckShapeless = "0.3.1"


### PR DESCRIPTION
This PR removes the warning messages that are shown when the project is compiled. The messages are related to the use of higher kinds and implicit conversions. There are other messages about org.joda.convert.

This PR resolves 47deg/nine-cards-v2#335

@noelmarkham Could you review please? Thanks
