### PR TITLE
9C-401: Adds unit tests for shared collection persistence services

### DIFF
--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/SharedCollectionPersistenceServices.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/SharedCollectionPersistenceServices.scala
@@ -38,10 +38,13 @@ class SharedCollectionPersistenceServices(
       fields = SharedCollectionPackage.allFields,
       values = (collectionId, packageName))
 
-  def addPackages(data: List[(Long, String)]): ConnectionIO[Int] =
+  def addPackages(collectionId: Long, packagesName: List[String]): ConnectionIO[Int] = {
+    val packages = packagesName map { (collectionId, _) }
+
     collectionPackagePersistence.updateMany(
       sql = PackageQueries.insert,
-      values = data)
+      values = packages)
+  }
 
   def getPackagesByCollection(
     collectionId: Long): ConnectionIO[List[SharedCollectionPackage]] =

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/UserPersistenceServices.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/UserPersistenceServices.scala
@@ -59,6 +59,11 @@ class UserPersistenceServices(
 
 object UserPersistenceServices {
 
+  case class UserData(
+    email: String,
+    apiKey: String,
+    sessionToken: String)
+
   implicit def userPersistenceServices(
     implicit userPersistence: Persistence[User],
     installationPersistence: Persistence[Installation]) = new UserPersistenceServices

--- a/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/NineCardsScalacheckGen.scala
+++ b/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/NineCardsScalacheckGen.scala
@@ -1,6 +1,13 @@
 package com.fortysevendeg.ninecards.services.persistence
 
+import java.sql.Timestamp
+import java.time.Instant
+
 import com.fortysevendeg.ninecards.services.persistence.NineCardsGenEntities._
+import com.fortysevendeg.ninecards.services.persistence.SharedCollectionPersistenceServices.SharedCollectionData
+import com.fortysevendeg.ninecards.services.persistence.UserPersistenceServices.UserData
+import org.scalacheck.Gen.Parameters
+import org.scalacheck.Gen.Parameters.default
 import org.scalacheck.{Arbitrary, Gen}
 
 object NineCardsGenEntities {
@@ -24,19 +31,59 @@ trait NineCardsScalacheckGen {
 
   def fixedLengthString(size: Int) = Gen.listOfN(size, Gen.alphaChar).map(_.mkString)
 
+  val stringGenerator = Arbitrary.arbitrary[String]
+
   val emailGenerator: Gen[String] = for {
     mailbox <- nonEmptyString(50)
     topLevelDomain <- nonEmptyString(45)
     domain <- fixedLengthString(3)
   } yield s"$mailbox@$topLevelDomain.$domain"
 
+  val timestampGenerator: Gen[Timestamp] = Gen.choose(0l, 253402300799l) map { seconds =>
+    Timestamp.from(Instant.ofEpochSecond(seconds))
+  }
+
   val uuidGenerator: Gen[String] = Gen.uuid.map(_.toString)
 
-  implicit def abAndroidId: Arbitrary[AndroidId] = Arbitrary(uuidGenerator.map(AndroidId.apply))
+  val sharedCollectionDataGenerator: Gen[SharedCollectionData] = for {
+    publicIdentifier <- uuidGenerator
+    publishedOn <- timestampGenerator
+    description <- Gen.option[String](stringGenerator)
+    author <- stringGenerator
+    name <- stringGenerator
+    installations <- Gen.posNum[Int]
+    views <- Gen.posNum[Int]
+    category <- stringGenerator
+    icon <- stringGenerator
+    community <- Gen.oneOf(true, false)
+  } yield SharedCollectionData(
+    publicIdentifier,
+    None,
+    publishedOn,
+    description = description,
+    author = author,
+    name = name,
+    installations = installations,
+    views = views,
+    category = category,
+    icon = icon,
+    community = community)
 
-  implicit def abApiKey: Arbitrary[ApiKey] = Arbitrary(uuidGenerator.map(ApiKey.apply))
+  val userDataGenerator: Gen[UserData] = for {
+    email <- emailGenerator
+    apiKey <- uuidGenerator
+    sessionToken <- uuidGenerator
+  } yield UserData(email, apiKey, sessionToken)
 
-  implicit def abEmail: Arbitrary[Email] = Arbitrary(emailGenerator.map(Email.apply))
+  implicit val abAndroidId: Arbitrary[AndroidId] = Arbitrary(uuidGenerator.map(AndroidId.apply))
 
-  implicit def abSessionToken: Arbitrary[SessionToken] = Arbitrary(uuidGenerator.map(SessionToken.apply))
+  implicit val abApiKey: Arbitrary[ApiKey] = Arbitrary(uuidGenerator.map(ApiKey.apply))
+
+  implicit val abEmail: Arbitrary[Email] = Arbitrary(emailGenerator.map(Email.apply))
+
+  implicit val abSessionToken: Arbitrary[SessionToken] = Arbitrary(uuidGenerator.map(SessionToken.apply))
+
+  implicit val abSharedCollectionData: Arbitrary[SharedCollectionData] = Arbitrary(sharedCollectionDataGenerator)
+
+  implicit val abUserData: Arbitrary[UserData] = Arbitrary(userDataGenerator)
 }

--- a/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/SharedCollectionPersistenceServicesSpec.scala
+++ b/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/SharedCollectionPersistenceServicesSpec.scala
@@ -1,0 +1,225 @@
+package com.fortysevendeg.ninecards.services.persistence
+
+import com.fortysevendeg.ninecards.services.free.domain._
+import com.fortysevendeg.ninecards.services.persistence.SharedCollectionPersistenceServices.SharedCollectionData
+import com.fortysevendeg.ninecards.services.persistence.UserPersistenceServices.UserData
+import doobie.imports._
+import org.specs2.ScalaCheck
+import org.specs2.matcher.DisjunctionMatchers
+import org.specs2.mutable.Specification
+import org.specs2.specification.BeforeEach
+import shapeless.syntax.std.product._
+
+import scalaz.std.iterable._
+
+class SharedCollectionPersistenceServicesSpec
+  extends Specification
+    with BeforeEach
+    with ScalaCheck
+    with DomainDatabaseContext
+    with DisjunctionMatchers
+    with NineCardsScalacheckGen {
+
+  sequential
+
+  def before = {
+    flywaydb.clean()
+    flywaydb.migrate()
+  }
+
+  "addCollection" should {
+    "create a new shared collection when an existing user id is given" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val id = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- sharedCollectionPersistenceServices.addCollection[Long](
+            collectionData.copy(userId = Option(u)))
+        } yield c).transact(transactor).run
+
+        val storedCollection = sharedCollectionPersistenceServices.getCollectionById(
+          id = id).transact(transactor).run
+
+        storedCollection must beSome[SharedCollection].which {
+          collection => collection.publicIdentifier must_== collectionData.publicIdentifier
+        }
+      }
+    }
+
+    "create a new shared collection without a defined user id" in {
+      prop { (collectionData: SharedCollectionData) =>
+        val id: Long = sharedCollectionPersistenceServices.addCollection[Long](
+          collectionData.copy(userId = None)).transact(transactor).run
+
+        val storedCollection = sharedCollectionPersistenceServices.getCollectionById(
+          id = id).transact(transactor).run
+
+        storedCollection must beSome[SharedCollection].which {
+          collection => collection.publicIdentifier must_== collectionData.publicIdentifier
+        }
+      }
+    }
+  }
+
+  "getCollectionById" should {
+    "return None if the table is empty" in {
+      prop { (id: Long) =>
+        val collection = sharedCollectionPersistenceServices.getCollectionById(
+          id = id).transact(transactor).run
+
+        collection must beNone
+      }
+    }
+    "return a collection if there is a record with the given id in the database" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val id = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+        } yield c).transact(transactor).run
+
+        val storedCollection = sharedCollectionPersistenceServices.getCollectionById(
+          id = id).transact(transactor).run
+
+        storedCollection must beSome[SharedCollection].which {
+          collection => collection.publicIdentifier must_== collectionData.publicIdentifier
+        }
+      }
+    }
+    "return None if there isn't any collection with the given id in the database" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val id = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+        } yield c).transact(transactor).run
+
+        val storedCollection = sharedCollectionPersistenceServices.getCollectionById(
+          id = id + 1000000).transact(transactor).run
+
+        storedCollection must beNone
+      }
+    }
+  }
+
+  "getCollectionByPublicIdentifier" should {
+    "return None if the table is empty" in {
+      prop { (publicIdentifier: String) =>
+
+        val collection = sharedCollectionPersistenceServices.getCollectionByPublicIdentifier(
+          publicIdentifier = publicIdentifier).transact(transactor).run
+
+        collection must beNone
+      }
+    }
+    "return a collection if there is a record with the given public identifier in the database" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val id = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+        } yield c).transact(transactor).run
+
+        val storedCollection = sharedCollectionPersistenceServices.getCollectionByPublicIdentifier(
+          publicIdentifier = collectionData.publicIdentifier).transact(transactor).run
+
+        storedCollection must beSome[SharedCollection].which {
+          collection =>
+            collection.id must_== id
+            collection.publicIdentifier must_== collectionData.publicIdentifier
+        }
+      }
+    }
+    "return None if there isn't any collection with the given public identifier in the database" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val id = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+        } yield c).transact(transactor).run
+
+        val collection = sharedCollectionPersistenceServices.getCollectionByPublicIdentifier(
+          publicIdentifier = collectionData.publicIdentifier.reverse).transact(transactor).run
+
+        collection must beNone
+      }
+    }
+  }
+
+  "addPackage" should {
+    "create a new package associated with an existing shared collection" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData, packageName: String) =>
+        val collectionId = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+        } yield c).transact(transactor).run
+
+        val packageId = sharedCollectionPersistenceServices.addPackage[Long](
+          collectionId,
+          packageName).transact(transactor).run
+
+        val storedPackages = sharedCollectionPersistenceServices.getPackagesByCollection(
+          collectionId).transact(transactor).run
+
+        storedPackages must contain { p: SharedCollectionPackage =>
+          p.id must_== packageId
+        }.atMostOnce
+      }
+    }
+  }
+
+  "addPackages" should {
+    "create new packages associated with an existing shared collection" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData, packagesName: List[String]) =>
+        val collectionId = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+        } yield c).transact(transactor).run
+
+        val created = sharedCollectionPersistenceServices.addPackages(
+          collectionId,
+          packagesName).transact(transactor).run
+
+        created must_== packagesName.size
+      }
+    }
+  }
+
+  "getPackagesByCollection" should {
+    "return an empty list if the table is empty" in {
+      prop { (collectionId: Long) =>
+        val packages = sharedCollectionPersistenceServices.getPackagesByCollection(
+          collectionId).transact(transactor).run
+
+        packages must beEmpty
+      }
+    }
+    "return a list of packages associated with the given shared collection" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData, packagesName: List[String]) =>
+        val collectionId = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          _ <- insertItems(SharedCollectionPackage.Queries.insert, packagesName map { (c, _) })
+        } yield c).transact(transactor).run
+
+        val packages = sharedCollectionPersistenceServices.getPackagesByCollection(
+          collectionId).transact(transactor).run
+
+        packages must haveSize(packagesName.size)
+
+        packages must contain { p: SharedCollectionPackage =>
+          p.sharedCollectionId must_=== collectionId
+        }.forall
+      }
+    }
+    "return an empty list if there isn't any package associated with the given collection" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData, packagesName: List[String]) =>
+        val collectionId = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          _ <- insertItems(SharedCollectionPackage.Queries.insert, packagesName map { (c, _) })
+        } yield c).transact(transactor).run
+
+        val packages = sharedCollectionPersistenceServices.getPackagesByCollection(
+          collectionId + 1000000).transact(transactor).run
+
+        packages must beEmpty
+      }
+    }
+  }
+}

--- a/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/SharedCollectionSubscriptionPersistenceServicesSpec.scala
+++ b/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/SharedCollectionSubscriptionPersistenceServicesSpec.scala
@@ -1,0 +1,273 @@
+package com.fortysevendeg.ninecards.services.persistence
+
+import com.fortysevendeg.ninecards.services.free.domain._
+import com.fortysevendeg.ninecards.services.persistence.SharedCollectionPersistenceServices.SharedCollectionData
+import com.fortysevendeg.ninecards.services.persistence.UserPersistenceServices.UserData
+import doobie.imports._
+import org.specs2.ScalaCheck
+import org.specs2.matcher.DisjunctionMatchers
+import org.specs2.mutable.Specification
+import org.specs2.specification.BeforeEach
+import shapeless.syntax.std.product._
+
+class SharedCollectionSubscriptionPersistenceServicesSpec
+  extends Specification
+    with BeforeEach
+    with ScalaCheck
+    with DomainDatabaseContext
+    with DisjunctionMatchers
+    with NineCardsScalacheckGen {
+
+  sequential
+
+  def before = {
+    flywaydb.clean()
+    flywaydb.migrate()
+  }
+
+  "addSubscription" should {
+    "create a new subscriptions when an existing user and shared collection is given" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val (userId: Long, collectionId: Long) = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+        } yield (u, c)).transact(transactor).run
+
+        val id: Long = scSubscriptionPersistenceServices.addSubscription[Long](
+          collectionId = collectionId,
+          userId = userId).transact(transactor).run
+
+        val storedSubscription =
+          scSubscriptionPersistenceServices.getSubscriptionById(id).transact(transactor).run
+
+        storedSubscription must beSome[SharedCollectionSubscription].which { subscription =>
+          subscription.sharedCollectionId must_== collectionId
+          subscription.userId must_== userId
+        }
+      }
+    }
+  }
+
+  "getSubscriptionByCollection" should {
+    "return an empty list if the table is empty" in {
+      prop { (collectionId: Long) =>
+        val subscriptions =
+          scSubscriptionPersistenceServices.getSubscriptionsByCollection(
+            collectionId = collectionId).transact(transactor).run
+
+        subscriptions must beEmpty
+      }
+    }
+    "return a list of subscriptions associated with the given collection" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val collectionId = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          s <- insertItem(SharedCollectionSubscription.Queries.insert, (c, u))
+        } yield c).transact(transactor).run
+
+        val storedSubscriptions =
+          scSubscriptionPersistenceServices.getSubscriptionsByCollection(
+            collectionId = collectionId).transact(transactor).run
+
+        storedSubscriptions must contain { subscription: SharedCollectionSubscription =>
+          subscription.sharedCollectionId must_== collectionId
+        }.forall
+      }
+    }
+    "return an empty list if there isn't any subscription associated with the given collection" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val collectionId = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          _ <- insertItem(SharedCollectionSubscription.Queries.insert, (c, u))
+        } yield c).transact(transactor).run
+
+        val subscriptions = scSubscriptionPersistenceServices.getSubscriptionsByCollection(
+          collectionId = collectionId + 1000000).transact(transactor).run
+
+        subscriptions must beEmpty
+      }
+    }
+  }
+
+  "getSubscriptionByCollectionAndUser" should {
+    "return None if the table is empty" in {
+      prop { (userId: Long, collectionId: Long) =>
+        val subscription = scSubscriptionPersistenceServices.getSubscriptionByCollectionAndUser(
+          collectionId = collectionId,
+          userId = userId).transact(transactor).run
+
+        subscription must beNone
+      }
+    }
+    "return a subscription if there is a record for the given user and collection in the database" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val (userId: Long, collectionId: Long) = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          _ <- insertItem(SharedCollectionSubscription.Queries.insert, (c, u))
+        } yield (u, c)).transact(transactor).run
+
+        val subscription = scSubscriptionPersistenceServices.getSubscriptionByCollectionAndUser(
+          collectionId = collectionId,
+          userId = userId).transact(transactor).run
+
+        subscription must beSome[SharedCollectionSubscription].which { s =>
+          s.sharedCollectionId must_== collectionId
+          s.userId must_== userId
+        }
+      }
+    }
+    "return None if there isn't any subscription for the given user and collection in the database" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val (userId: Long, collectionId: Long) = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          _ <- insertItem(SharedCollectionSubscription.Queries.insert, (c, u))
+        } yield (u, c)).transact(transactor).run
+
+        val subscription = scSubscriptionPersistenceServices.getSubscriptionByCollectionAndUser(
+          collectionId = collectionId + 1000000,
+          userId = userId + 1000000).transact(transactor).run
+
+        subscription must beNone
+      }
+    }
+  }
+
+  "getSubscriptionById" should {
+    "return None if the table is empty" in {
+      prop { (id: Long) =>
+        val subscription = scSubscriptionPersistenceServices.getSubscriptionById(
+          subscriptionId = id).transact(transactor).run
+
+        subscription must beNone
+      }
+    }
+    "return a subscription if there is a record for the given id in the database" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val (userId: Long, collectionId: Long, id: Long) = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          s <- insertItem(SharedCollectionSubscription.Queries.insert, (c, u))
+        } yield (u, c, s)).transact(transactor).run
+
+        val storedSubscription = scSubscriptionPersistenceServices.getSubscriptionById(
+          subscriptionId = id).transact(transactor).run
+
+        storedSubscription must beSome[SharedCollectionSubscription].which { subscription =>
+          subscription.sharedCollectionId must_== collectionId
+          subscription.userId must_== userId
+        }
+      }
+    }
+    "return None if there isn't any subscription for the given id in the database" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val id = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          s <- insertItem(SharedCollectionSubscription.Queries.insert, (c, u))
+        } yield s).transact(transactor).run
+
+        val storedSubscription = scSubscriptionPersistenceServices.getSubscriptionById(
+          subscriptionId = id + 1000000).transact(transactor).run
+
+        storedSubscription must beNone
+      }
+    }
+  }
+
+  "getSubscriptionByUser" should {
+    "return an empty list if the table is empty" in {
+      prop { (userId: Long) =>
+        val subscriptions = scSubscriptionPersistenceServices.getSubscriptionsByUser(
+          userId = userId).transact(transactor).run
+
+        subscriptions must beEmpty
+      }
+    }
+    "return a list of subscriptions associated for the given user" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val userId = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          _ <- insertItem(SharedCollectionSubscription.Queries.insert, (c, u))
+        } yield u).transact(transactor).run
+
+        val storedSubscriptions = scSubscriptionPersistenceServices.getSubscriptionsByUser(
+          userId = userId).transact(transactor).run
+
+        storedSubscriptions must contain { subscription: SharedCollectionSubscription =>
+          subscription.userId must_== userId
+        }.forall
+      }
+    }
+    "return an empty list if there isn't any subscription associated for the given user" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val userId = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          _ <- insertItem(SharedCollectionSubscription.Queries.insert, (c, u))
+        } yield u).transact(transactor).run
+
+        val subscriptions = scSubscriptionPersistenceServices.getSubscriptionsByUser(
+          userId = userId + 1000000).transact(transactor).run
+
+        subscriptions must beEmpty
+      }
+    }
+  }
+
+  "removeSubscription" should {
+    "return 0 there isn't any subscription for the given id in the database" in {
+      prop { (id: Long) =>
+        val count = scSubscriptionPersistenceServices.removeSubscription(
+          subscriptionId = id).transact(transactor).run
+
+        count must_== 0
+      }
+    }
+    "return 1 if there is a subscription for the given id in the database" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val id = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          s <- insertItem(SharedCollectionSubscription.Queries.insert, (c, u))
+        } yield s).transact(transactor).run
+
+        val deleted = scSubscriptionPersistenceServices.removeSubscription(
+          subscriptionId = id).transact(transactor).run
+
+        deleted must_== 1
+      }
+    }
+  }
+
+  "removeSubscriptionByCollectionAndUser" should {
+    "return 0 there isn't any subscription for the given user and collection in the database" in {
+      prop { (userId: Long, collectionId: Long) =>
+        val deleted = scSubscriptionPersistenceServices.removeSubscriptionByCollectionAndUser(
+          collectionId = collectionId,
+          userId = userId).transact(transactor).run
+
+        deleted must_== 0
+      }
+    }
+    "return 1 if there is a subscription for the given user and collection in the database" in {
+      prop { (userData: UserData, collectionData: SharedCollectionData) =>
+        val (userId: Long, collectionId: Long) = (for {
+          u <- insertItem(User.Queries.insert, userData.toTuple)
+          c <- insertItem(SharedCollection.Queries.insert, collectionData.copy(userId = Option(u)).toTuple)
+          s <- insertItem(SharedCollectionSubscription.Queries.insert, (c, u))
+        } yield (u,c)).transact(transactor).run
+
+        val deleted = scSubscriptionPersistenceServices.removeSubscriptionByCollectionAndUser(
+          collectionId = collectionId,
+          userId = userId).transact(transactor).run
+
+        deleted must_== 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds unit test for the classes added in 47deg/nine-cards-v2#184 to persist the shared collection info.

This PR resolves 47deg/nine-cards-v2#401 issue

@noelmarkham Could you take a look please? Thanks!
