### PR TITLE
9C-451 FIX issues with Spray Routes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,7 @@ Possible ways to define the database connection info:
 
 ##Authentication
 ```
-X-Appsly-Application-Id : appId
-
-X-Appsly-REST-API-Key : restAPIKey
-
-X-Appsly-Session-Token : sessionToken
+X-Session-Token : sessionToken
 
 X-Android-ID : androidId
 

--- a/assets/postman/NineCardsV2.json.postman_collection
+++ b/assets/postman/NineCardsV2.json.postman_collection
@@ -35,7 +35,7 @@
 	"requests": [
 		{
 			"id": "052efc3e-f341-caaf-1b35-80d599bc3229",
-			"headers": "X-Appsly-Application-Id: {{appid}}\nX-Appsly-REST-API-Key: {{appkey}}\nContent-Type: application/json\n",
+			"headers": "Content-Type: application/json\n",
 			"url": "http://{{baseurl}}/login",
 			"preRequestScript": "",
 			"pathVariables": {},
@@ -55,8 +55,8 @@
 		},
 		{
 			"id": "17f43c2f-f010-d93c-15bf-a3799f7eee31",
-			"headers": "Accept: \"application/json\"\nContent-Type: application/json\nX-Appsly-Application-Id: {{appid}}\nX-Appsly-REST-API-Key: {{appkey}}\nX-Appsly-Session-Token: {{token}}\nX-Android-ID: {{androidid}}\nX-Android-Market-Localization: {{localization}}\n",
-			"url": "https://{{baseurl}}/ninecards/collections",
+			"headers": "Accept: \"application/json\"\nContent-Type: application/json\nX-Session-Token: {{token}}\nX-Android-ID: {{androidid}}\nX-Android-Market-Localization: {{localization}}\nX-Auth-Token: {{COMPUTE_AUTH_TOKEN}}\n",
+			"url": "http://{{baseurl}}/collections",
 			"preRequestScript": "",
 			"pathVariables": {},
 			"method": "GET",
@@ -74,8 +74,8 @@
 		},
 		{
 			"id": "27589784-4c58-4a91-e9ba-db997b69c9ef",
-			"headers": "Accept: \"application/json\"\nContent-Type: application/json\nX-Appsly-Application-Id: {{appid}}\nX-Appsly-REST-API-Key: {{appkey}}\nX-Appsly-Session-Token: {{token}}\nX-Android-ID: {{androidid}}\nX-Android-Market-Localization: {{localization}}\n",
-			"url": "https://{{baseurl}}/ninecards/collections/5346f6802000003802fcf3ee",
+			"headers": "Accept: \"application/json\"\nContent-Type: application/json\nX-Session-Token: {{token}}\nX-Android-ID: {{androidid}}\nX-Android-Market-Localization: {{localization}}\nX-Auth-Token: {{COMPUTE_AUTH_TOKEN}}\n",
+			"url": "http://{{baseurl}}/collections/5346f6802000003802fcf3ee",
 			"preRequestScript": "",
 			"pathVariables": {},
 			"method": "GET",
@@ -93,8 +93,8 @@
 		},
 		{
 			"id": "4f54e578-ad87-6df4-3afa-da46df17c319",
-			"headers": "Accept: \"application/json\"\nContent-Type: application/json\nX-Appsly-Application-Id: {{appid}}\nX-Appsly-REST-API-Key: {{appkey}}\nX-Appsly-Session-Token: {{token}}\nX-Android-ID: {{androidid}}\nX-Android-Market-Localization: {{localization}}\n",
-			"url": "https://{{baseurl}}/ninecards/collections",
+			"headers": "Accept: \"application/json\"\nContent-Type: application/json\nX-Session-Token: {{token}}\nX-Android-ID: {{androidid}}\nX-Android-Market-Localization: {{localization}}\nX-Auth-Token: {{COMPUTE_AUTH_TOKEN}}\n",
+			"url": "http://{{baseurl}}/collections",
 			"preRequestScript": "",
 			"pathVariables": {},
 			"method": "POST",
@@ -113,8 +113,8 @@
 		},
 		{
 			"id": "a7134bb9-2d20-c72e-58d3-750818f6e6c8",
-			"headers": "Accept: \"application/json\"\nContent-Type: application/json\nX-Appsly-Application-Id: {{appid}}\nX-Appsly-REST-API-Key: {{appkey}}\nX-Appsly-Session-Token: {{token}}\nX-Android-ID: {{androidid}}\nX-Android-Market-Localization: {{localization}}\n",
-			"url": "https://{{baseurl}}/ninecards/collections/5346f6802000003802fcf3ee/subscribe",
+			"headers": "Accept: \"application/json\"\nContent-Type: application/json\nX-Session-Token: {{token}}\nX-Android-ID: {{androidid}}\nX-Android-Market-Localization: {{localization}}\nX-Auth-Token: {{COMPUTE_AUTH_TOKEN}}\n",
+			"url": "http://{{baseurl}}/collections/5346f6802000003802fcf3ee/subscribe",
 			"preRequestScript": "",
 			"pathVariables": {},
 			"method": "PUT",
@@ -133,8 +133,8 @@
 		},
 		{
 			"id": "ac4262a3-5453-c0a2-ab09-90f50176fe3f",
-			"headers": "Accept: \"application/json\"\nContent-Type: application/json\nX-Appsly-Application-Id: {{appid}}\nX-Appsly-REST-API-Key: {{appkey}}\nX-Appsly-Session-Token: {{token}}\nX-Android-ID: {{androidid}}\nX-Android-Market-Localization: {{localization}}\n",
-			"url": "https://{{baseurl}}/ninecards/collections/5346f6802000003802fcf3ee/subscribe",
+			"headers": "Accept: \"application/json\"\nContent-Type: application/json\nX-Session-Token: {{token}}\nX-Android-ID: {{androidid}}\nX-Android-Market-Localization: {{localization}}\X-Auth-Token: {{COMPUTE_AUTH_TOKEN}}\n",
+			"url": "http://{{baseurl}}/collections/5346f6802000003802fcf3ee/subscribe",
 			"preRequestScript": "",
 			"pathVariables": {},
 			"method": "DELETE",
@@ -153,7 +153,7 @@
 		},
 		{
 			"id": "d2f159bd-33dc-b9a3-7386-d7dffeaa0d0d",
-			"headers": "X-Appsly-Application-Id: {{appid}}\nX-Appsly-REST-API-Key: {{appkey}}\nContent-Type: application/json\nX-Appsly-Session-Token: {{token}}\nX-Android-ID: {{androidId}}\nX-Android-Market-Localization: {{location}}\n",
+			"headers": "Content-Type: application/json\nX-Session-Token: {{token}}\nX-Android-ID: {{androidId}}\nX-Android-Market-Localization: {{location}}\nX-Auth-Token: {{COMPUTE_AUTH_TOKEN}}\n",
 			"url": "http://{{baseurl}}/installations",
 			"preRequestScript": "",
 			"pathVariables": {},

--- a/modules/api/src/main/resources/apiDocs/index.html
+++ b/modules/api/src/main/resources/apiDocs/index.html
@@ -92,11 +92,6 @@
 
       window.swaggerUi.load();
 
-      // This two lines are an example on how to auto-populate authorization headers for our API. We should take a look at this later,
-      // so users won't need to put the auth headers as a parameter in every request. But for now, let's leave it like commented out:
-      // window.swaggerUi.api.clientAuthorizations.add("keyAppId", new SwaggerClient.ApiKeyAuthorization("X-Appsly-Application-Id", "ninecards", "header"));
-      // window.swaggerUi.api.clientAuthorizations.add("keyApiKey", new SwaggerClient.ApiKeyAuthorization("X-Appsly-REST-API-Key", "myApiKeyXXXX123456789", "header"));
-
       function log() {
         if ('console' in window) {
           console.log.apply(console, arguments);

--- a/modules/api/src/main/resources/apiDocs/swagger.json
+++ b/modules/api/src/main/resources/apiDocs/swagger.json
@@ -2114,22 +2114,8 @@
         }
     },
     "parameters": {
-        "appId": {
-            "name": "X-Appsly-Application-Id",
-            "description": "Application ID needed for authentication in appsly.",
-            "in": "header",
-            "type": "string",
-            "required": true
-        },
-        "restApiKey": {
-            "name": "X-Appsly-REST-API-Key",
-            "description": "REST API Key in appsly.",
-            "in": "header",
-            "type": "string",
-            "required": true
-        },
         "sessionToken": {
-            "name": "X-Appsly-Session-Token",
+            "name": "X-Session-Token",
             "description": "Appsly session token obtained from a valid login request.",
             "in": "header",
             "type": "string",

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsApi.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsApi.scala
@@ -1,7 +1,6 @@
 package com.fortysevendeg.ninecards.api
 
 import akka.actor.{ Actor, ActorRefFactory }
-import com.fortysevendeg.ninecards.api.NineCardsApiHeaderCommons._
 import com.fortysevendeg.ninecards.api.NineCardsDirectives._
 import com.fortysevendeg.ninecards.api.NineCardsHeaders.Domain._
 import com.fortysevendeg.ninecards.api.converters.Converters._
@@ -54,13 +53,11 @@ class NineCardsRoutes(
 
   private[this] lazy val userRoute =
     pathEndOrSingleSlash {
-      requestLoginHeaders { (appId, apiKey) ⇒
-        nineCardsDirectives.authenticateLoginRequest { sessionToken: SessionToken ⇒
-          post {
-            entity(as[ApiLoginRequest]) { request ⇒
-              complete {
-                userProcesses.signUpUser(toLoginRequest(request, sessionToken)) map toApiLoginResponse
-              }
+      post {
+        entity(as[ApiLoginRequest]) { request ⇒
+          nineCardsDirectives.authenticateLoginRequest { sessionToken: SessionToken ⇒
+            complete {
+              userProcesses.signUpUser(toLoginRequest(request, sessionToken)) map toApiLoginResponse
             }
           }
         }

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsApiHeaderCommons.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsApiHeaderCommons.scala
@@ -1,24 +1,13 @@
 package com.fortysevendeg.ninecards.api
 
-import com.fortysevendeg.ninecards.api.NineCardsHeaders._
-import shapeless.HList._
-import shapeless.HNil
-import spray.http.StatusCodes
-import spray.routing.directives.HeaderDirectives._
-import spray.routing.{ HttpService, MissingHeaderRejection, RejectionHandler }
+import spray.http.StatusCodes.Unauthorized
+import spray.routing.{ Directives, MissingHeaderRejection, RejectionHandler }
 
-object NineCardsApiHeaderCommons {
+trait AuthHeadersRejectionHandler {
 
-  def requestLoginHeaders = for {
-    appId ← headerValueByName(headerAppId)
-    apiKey ← headerValueByName(headerApiKey)
-  } yield appId :: apiKey :: HNil
-
-}
-
-trait AuthHeadersRejectionHandler extends HttpService {
   implicit val authHeadersRejectionHandler = RejectionHandler {
     case MissingHeaderRejection(headerName: String) :: _ ⇒
-      complete(StatusCodes.Unauthorized, "Missing authorization headers needed for this request")
+      Directives.complete(Unauthorized, "Missing authorization headers needed for this request")
   }
+
 }

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsHeaders.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsHeaders.scala
@@ -5,19 +5,13 @@ import org.joda.time.DateTime
 object NineCardsHeaders {
 
   val headerAndroidId = "X-Android-ID"
-  val headerApiKey = "X-Appsly-REST-API-Key"
-  val headerAppId = "X-Appsly-Application-Id"
   val headerMarketLocalization = "X-Android-Market-Localization"
-  val headerSessionToken = "X-Appsly-Session-Token"
+  val headerSessionToken = "X-Session-Token"
   val headerAuthToken = "X-Auth-Token"
 
   object Domain {
 
     case class AndroidId(value: String) extends AnyVal
-
-    case class ApiKey(value: String) extends AnyVal
-
-    case class ApplicationId(value: String) extends AnyVal
 
     case class AuthToken(value: String) extends AnyVal
 


### PR DESCRIPTION
This PR resolves 451.

We remove two headers previously used for login authentication, called `X-Appsly-Application-Id` and `X-Appsly-REST-API-Key`. This leads to removing the `requestLoginHeaders` spray directive. We also rename header "X-Appsly-Session-Token" to "X-Session-Token". We also remove from the documentation, the README, the postman collection any reference to these headers.

@franciscodr ¿Could you review?
@javipacheco @noelmarkham ¿Any comments?
