### PR TITLE
JP - Swagger docs as vendored lib

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+modules/api/src/main/resources/apiDocs/* linguist-vendored


### PR DESCRIPTION
This PR fixes the main language project, ignoring swagger documentation:

![screen shot 2016-08-01 at 14 42 34](https://cloud.githubusercontent.com/assets/4879373/17295485/a62efa8a-57fc-11e6-8922-09ce15b59067.png)

It should be 100% Scala if we exclude Swagger code.

Please, @javipacheco @franciscodr could you take a look? Thanks!
