### PR TITLE
9C-592: Fixes user authentication error in NineCards backend app

### DIFF
--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsDirectives.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsDirectives.scala
@@ -60,10 +60,12 @@ class NineCardsDirectives(
 
   def authenticateUser: Directive1[UserContext] = for {
     uri ← requestUri
+    herokuForwardedProtocol ← optionalHeaderValueByName(headerHerokuForwardedProto)
+    herokuUri = herokuForwardedProtocol.filterNot(_.isEmpty).fold(uri)(uri.withScheme)
     sessionToken ← headerValueByName(headerSessionToken)
     androidId ← headerValueByName(headerAndroidId)
     authToken ← headerValueByName(headerAuthToken)
-    userId ← authenticate(validateUser(sessionToken, androidId, authToken, uri))
+    userId ← authenticate(validateUser(sessionToken, androidId, authToken, herokuUri))
   } yield UserContext(UserId(userId), AndroidId(androidId)) :: HNil
 
   val googlePlayInfo: Directive1[GooglePlayContext] = for {

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsHeaders.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/NineCardsHeaders.scala
@@ -9,6 +9,7 @@ object NineCardsHeaders {
   val headerMarketLocalization = "X-Android-Market-Localization"
   val headerSessionToken = "X-Session-Token"
   val headerAuthToken = "X-Auth-Token"
+  val headerHerokuForwardedProto = "x-forwarded-proto"
 
   object Domain {
 


### PR DESCRIPTION
This pull request fixes a bug related to the user authentication in NineCards backend app.

It fixes 47deg/nine-cards-v2#592

This error is caused by the used `URI` to check if the provided auth token is valid. 

The used  protocol between the client and the load balancer is `https`, but the requests between the load balancer and the server use `http`. So we have to check the header `x-forwarded-proto` provided by Heroku to detect the right protocol.

@juanpedromoreno Could you take a look please? Thanks!
