### PR TITLE
9C-608: Increases the length of the description field in sharedcollection table to 512

### DIFF
--- a/modules/api/src/main/resources/db/migration/V1__Add_new_tables_for_v1.sql
+++ b/modules/api/src/main/resources/db/migration/V1__Add_new_tables_for_v1.sql
@@ -19,7 +19,7 @@ CREATE TABLE SharedCollections (
   publicIdentifier character varying(100) NOT NULL,
   userId BIGINT REFERENCES Users(id),
   publishedOn timestamp NOT NULL,
-  description character varying(100),
+  description character varying(512),
   author character varying(100) NOT NULL,
   name character varying(100) NOT NULL,
   installations INTEGER NOT NULL DEFAULT 0,


### PR DESCRIPTION
This pull request increases the length of the `description` field of the `sharedcollection` table to 512.

It closes https://github.com/47deg/nine-cards-v2/issues/608

@juanpedromoreno Could you take a look please? Thanks!
