### PR TITLE
Removes all unnecessary fields from TokenInfo object

### DIFF
--- a/modules/processes/src/test/scala/com/fortysevendeg/ninecards/processes/GoogleApiProcessesSpec.scala
+++ b/modules/processes/src/test/scala/com/fortysevendeg/ninecards/processes/GoogleApiProcessesSpec.scala
@@ -48,18 +48,8 @@ trait GoogleApiProcessesContext {
   val tokenId = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjcxMjI3MjFlZWQwYjQ1YmUxNWUzMGI2YThhOThjOTM3ZTJlNmQxN"
 
   val tokenInfo = TokenInfo(
-    iss            = "accounts.google.com",
-    at_hash        = "rXE2xjjK6YP9QtfKXTBZmQ",
-    aud            = "123456789012.apps.googleusercontent.com",
-    sub            = "106222693719864970737",
     email_verified = "true",
-    azp            = "123456789012.apps.googleusercontent.com",
-    hd             = Option("test.com"),
-    email          = email,
-    iat            = "1457529032",
-    exp            = "1457532632",
-    alg            = "RS256",
-    kid            = "7122721eed0b45be15e30b6a8a98c937e2e6d16d"
+    email          = email
   )
 
   val wrongTokenInfo = WrongTokenInfo(error_description = "Invalid Value")

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/domain/TokenInfo.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/domain/TokenInfo.scala
@@ -1,18 +1,8 @@
 package com.fortysevendeg.ninecards.services.free.domain
 
 case class TokenInfo(
-  iss: String,
-  at_hash: String,
-  aud: String,
-  sub: String,
   email_verified: String,
-  azp: String,
-  hd: Option[String],
-  email: String,
-  iat: String,
-  exp: String,
-  alg: String,
-  kid: String
+  email: String
 )
 
 case class WrongTokenInfo(error_description: String)


### PR DESCRIPTION
I've detected that for some tokens the `at_hash` field is missing from the response. 

Because we only need the fields `email_verified` and `email`, I've modified the `TokenInfo` model to contains only these fields.

Please @diesalbla could you review? Thanks!
