### PR TITLE
9C-649: Avoid calling Google Play service if an empty list is passed in categorizeApps method

### DIFF
--- a/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/ApplicationProcesses.scala
+++ b/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/ApplicationProcesses.scala
@@ -10,14 +10,14 @@ class ApplicationProcesses[F[_]](implicit services: GooglePlay.Services[F]) {
   def categorizeApps(
     packagesName: List[String],
     authParams: AuthParams
-  ): Free[F, CategorizeAppsResponse] = packagesName match {
-    case Nil ⇒ Free.pure[F, CategorizeAppsResponse](CategorizeAppsResponse(Nil, Nil))
-    case _ ⇒
+  ): Free[F, CategorizeAppsResponse] =
+    if (packagesName.isEmpty)
+      Free.pure[F, CategorizeAppsResponse](CategorizeAppsResponse(Nil, Nil))
+    else
       services.resolveMany(
         packageNames = packagesName,
         auth         = toAuthParamsServices(authParams)
       ) map toCategorizeAppsResponse
-  }
 }
 
 object ApplicationProcesses {

--- a/modules/processes/src/test/scala/com/fortysevendeg/ninecards/processes/ApplicationProcessesSpec.scala
+++ b/modules/processes/src/test/scala/com/fortysevendeg/ninecards/processes/ApplicationProcessesSpec.scala
@@ -2,9 +2,9 @@ package com.fortysevendeg.ninecards.processes
 
 import cats.free.Free
 import com.fortysevendeg.ninecards.processes.NineCardsServices._
-import com.fortysevendeg.ninecards.processes.messages.ApplicationMessages.{AuthParams, CategorizeAppsResponse, CategorizedApp}
+import com.fortysevendeg.ninecards.processes.messages.ApplicationMessages.{ AuthParams, CategorizeAppsResponse, CategorizedApp }
 import com.fortysevendeg.ninecards.services.free.algebra.GooglePlay.Services
-import com.fortysevendeg.ninecards.services.free.domain.GooglePlay.{AppInfo, AppsInfo, AuthParams => GooglePlayAuthParams}
+import com.fortysevendeg.ninecards.services.free.domain.GooglePlay.{ AppInfo, AppsInfo, AuthParams ⇒ GooglePlayAuthParams }
 import org.specs2.matcher.Matchers
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification


### PR DESCRIPTION
This pull request checks if an empty list of packages name is passed to `categorizeApps` methods. In this case, an empty response is returned without calling the Google Play service.

It also adds unit test for this method.

It closes 47deg/nine-cards-v2#649

@diesalbla Could you take a look please? Thanks
