### PR TITLE
9C-638: Improves publishedOn output format

### DIFF
--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/JsonFormats.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/JsonFormats.scala
@@ -18,7 +18,7 @@ trait JsonFormats
   with SprayJsonSupport {
 
   implicit object JodaDateTimeFormat extends RootJsonFormat[DateTime] {
-    val formatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    val formatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZoneUTC
     val dateExample = formatter.print(0)
 
     def error(v: String) = deserializationError(
@@ -41,7 +41,7 @@ trait JsonFormats
     )
 
     def read(json: JsValue): DateTime = json match {
-      case JsString(s) ⇒ decodeDateTime(Json.fromString(s).hcursor).fold(error(s), d ⇒ d)
+      case JsString(s) ⇒ decodeDateTime(Json.fromString(s).hcursor).fold(_ ⇒ error(s), d ⇒ d)
       case _ ⇒ error(json.toString)
     }
 

--- a/modules/api/src/test/scala/com/fortysevendeg/ninecards/api/JsonFormatsSpec.scala
+++ b/modules/api/src/test/scala/com/fortysevendeg/ninecards/api/JsonFormatsSpec.scala
@@ -1,39 +1,37 @@
 package com.fortysevendeg.ninecards.api
 
-import com.fortysevendeg.ninecards.services.free.domain.Category
 import org.joda.time.{ DateTime, DateTimeZone }
-import org.joda.time.format.DateTimeFormat
 import org.specs2.matcher.Matchers
 import org.specs2.mutable.Specification
+import spray.json.DefaultJsonProtocol._
 import spray.json._
 
-class JsonFormatsSpecification extends Specification with Matchers {
+class JsonFormatsSpec extends Specification with Matchers {
 
   sequential
 
   "JodaDateTimeFormat, the Json Format for dates," should {
 
     import com.fortysevendeg.ninecards.api.JsonFormats.JodaDateTimeFormat
-    import DefaultJsonProtocol._
 
     val date = new DateTime(2013, 5, 23, 0, 0, DateTimeZone.UTC)
 
     "transfer it to a Json string as format" in {
-      date.toJson must beEqualTo(JsString("2013-05-23T00:00:00.000000"))
-    }.pendingUntilFixed()
+      date.toJson must beEqualTo(JsString("2013-05-23T00:00:00.000+0000"))
+    }
 
     "parse it from a Json String" in {
-      val str = """ "2013-05-23T00:00:00.000000" """
+      val str = """ "2013-05-23T00:00:00.000+0000" """
       str.parseJson.convertTo[DateTime] shouldEqual date
-    }.pendingUntilFixed()
+    }
 
     case class MyDate(date: DateTime)
     implicit val format = jsonFormat1(MyDate)
 
     "use it properly in a record" in {
-      val str = """ { "date" : "2013-05-23T00:00:00.000000" } """
+      val str = """ { "date" : "2013-05-23T00:00:00.000Z" } """
       str.parseJson.convertTo[MyDate] shouldEqual MyDate(date)
-    }.pendingUntilFixed()
+    }
 
   }
 


### PR DESCRIPTION
This pull request removes the embedded quotes in `publishedon` JSON field. It also changes the date time format used to represent the dates.

The dates were displayed previously in this way: `"\"2016-08-16T14:55:30.574000\""`

And now they're displayed as: `"2016-08-19T08:34:57.525+0000"`

It closes 47deg/nine-cards-v2#638

@diesalbla Could you review please? Thanks!
