### PR TITLE
9C-730: Adds the number of subcriptions of a collection

### DIFF
--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/JsonFormats.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/JsonFormats.scala
@@ -57,7 +57,7 @@ trait JsonFormats
 
   implicit val appInfoFormat = jsonFormat7(AppInfo)
 
-  implicit val apiSharedCollection = jsonFormat11(ApiSharedCollection)
+  implicit val apiSharedCollection = jsonFormat12(ApiSharedCollection)
 
   implicit val apiSharedCollectionList = jsonFormat1(ApiSharedCollectionList)
 

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/converters/Converters.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/converters/Converters.scala
@@ -68,7 +68,8 @@ object Converters {
       icon             = info.collection.icon,
       community        = info.collection.community,
       packages         = info.collection.packages,
-      appsInfo         = info.appsInfo
+      appsInfo         = info.appsInfo,
+      subscriptions    = info.collection.subscriptionsCount
     )
 
   def toApiSharedCollectionList(response: GetCollectionsResponse): ApiSharedCollectionList =

--- a/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/messages/SharedCollectionMessages.scala
+++ b/modules/api/src/main/scala/com.fortysevendeg.ninecards/api/messages/SharedCollectionMessages.scala
@@ -33,7 +33,8 @@ object SharedCollectionMessages {
     icon: String,
     community: Boolean,
     packages: List[String],
-    appsInfo: List[AppInfo]
+    appsInfo: List[AppInfo],
+    subscriptions: Option[Long] = None
   )
 
   case class ApiSharedCollectionList(collections: List[ApiSharedCollection])

--- a/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/SharedCollectionProcesses.scala
+++ b/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/SharedCollectionProcesses.scala
@@ -13,7 +13,12 @@ import com.fortysevendeg.ninecards.services.free.algebra.DBResult.DBOps
 import com.fortysevendeg.ninecards.services.free.algebra.{ Firebase, GooglePlay }
 import com.fortysevendeg.ninecards.services.free.domain.Firebase._
 import com.fortysevendeg.ninecards.services.free.domain.GooglePlay.AppsInfo
-import com.fortysevendeg.ninecards.services.free.domain.{ Installation, SharedCollectionSubscription, SharedCollection ⇒ SharedCollectionServices }
+import com.fortysevendeg.ninecards.services.free.domain.{
+  BaseSharedCollection,
+  Installation,
+  SharedCollectionSubscription,
+  SharedCollection ⇒ SharedCollectionServices
+}
 import com.fortysevendeg.ninecards.services.persistence._
 import doobie.imports._
 
@@ -208,8 +213,8 @@ class SharedCollectionProcesses[F[_]](
     }
   }.rightXorT[Throwable]
 
-  private def getCollections(
-    sharedCollections: ConnectionIO[List[SharedCollectionServices]],
+  private def getCollections[T <: BaseSharedCollection](
+    sharedCollections: ConnectionIO[List[T]],
     authParams: AuthParams
   ) = {
 
@@ -245,11 +250,10 @@ class SharedCollectionProcesses[F[_]](
     } yield fillGooglePlayInfoForPackages(collections, appsInfo)
   }
 
-  private[this] def getCollectionPackages(collection: SharedCollectionServices): ConnectionIO[SharedCollection] =
-    collectionPersistence.getPackagesByCollection(collection.id) map { packages ⇒
+  private[this] def getCollectionPackages(collection: BaseSharedCollection): ConnectionIO[SharedCollection] =
+    collectionPersistence.getPackagesByCollection(collection.sharedCollectionId) map { packages ⇒
       toSharedCollection(collection, packages map (_.packageName))
     }
-
 }
 
 object SharedCollectionProcesses {

--- a/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/converters/Converters.scala
+++ b/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/converters/Converters.scala
@@ -12,9 +12,11 @@ import com.fortysevendeg.ninecards.services.free.domain.GooglePlay.{
   AuthParams ⇒ AuthParamServices
 }
 import com.fortysevendeg.ninecards.services.free.domain.{
+  BaseSharedCollection,
   Installation ⇒ InstallationServices,
   SharedCollection ⇒ SharedCollectionServices,
   SharedCollectionSubscription ⇒ SharedCollectionSubscriptionServices,
+  SharedCollectionWithAggregatedInfo,
   User ⇒ UserAppServices
 }
 import com.fortysevendeg.ninecards.services.persistence.SharedCollectionPersistenceServices.{
@@ -58,21 +60,30 @@ object Converters {
       community        = data.community
     )
 
+  def toSharedCollection: (BaseSharedCollection, List[String]) ⇒ SharedCollection = {
+    case (collection: SharedCollectionWithAggregatedInfo, packages) ⇒
+      toSharedCollection(collection.sharedCollectionData, packages, Option(collection.subscriptionsCount))
+    case (collection: SharedCollectionServices, packages) ⇒
+      toSharedCollection(collection, packages, None)
+  }
+
   def toSharedCollection(
     collection: SharedCollectionServices,
-    packages: List[String]
-  ): SharedCollection =
+    packages: List[String],
+    subscriptionCount: Option[Long]
+  ) =
     SharedCollection(
-      publicIdentifier = collection.publicIdentifier,
-      publishedOn      = collection.publishedOn,
-      author           = collection.author,
-      name             = collection.name,
-      installations    = collection.installations,
-      views            = collection.views,
-      category         = collection.category,
-      icon             = collection.icon,
-      community        = collection.community,
-      packages         = packages
+      publicIdentifier   = collection.publicIdentifier,
+      publishedOn        = collection.publishedOn,
+      author             = collection.author,
+      name               = collection.name,
+      installations      = collection.installations,
+      views              = collection.views,
+      category           = collection.category,
+      icon               = collection.icon,
+      community          = collection.community,
+      packages           = packages,
+      subscriptionsCount = subscriptionCount
     )
 
   def toSharedCollectionWithAppsInfo(

--- a/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/messages/SharedCollectionMessages.scala
+++ b/modules/processes/src/main/scala/com/fortysevendeg/ninecards/processes/messages/SharedCollectionMessages.scala
@@ -43,7 +43,8 @@ object SharedCollectionMessages {
     category: String,
     icon: String,
     community: Boolean,
-    packages: List[String]
+    packages: List[String],
+    subscriptionsCount: Option[Long] = None
   )
 
   case class SharedCollectionUpdateInfo(

--- a/modules/processes/src/test/scala/com/fortysevendeg/ninecards/processes/SharedCollectionProcessesSpec.scala
+++ b/modules/processes/src/test/scala/com/fortysevendeg/ninecards/processes/SharedCollectionProcessesSpec.scala
@@ -11,7 +11,7 @@ import com.fortysevendeg.ninecards.processes.messages.SharedCollectionMessages._
 import com.fortysevendeg.ninecards.processes.utils.DummyNineCardsConfig
 import com.fortysevendeg.ninecards.services.free.algebra.{ Firebase, GooglePlay }
 import com.fortysevendeg.ninecards.services.free.domain.Firebase.FirebaseError
-import com.fortysevendeg.ninecards.services.free.domain.{ SharedCollectionSubscription, SharedCollection ⇒ SharedCollectionServices }
+import com.fortysevendeg.ninecards.services.free.domain.{ SharedCollectionSubscription, SharedCollectionWithAggregatedInfo, SharedCollection ⇒ SharedCollectionServices }
 import com.fortysevendeg.ninecards.services.persistence._
 import doobie.imports._
 import org.mockito.Matchers.{ eq ⇒ mockEq }
@@ -81,7 +81,7 @@ trait SharedCollectionProcessesSpecification
 
     collectionPersistenceServices.getCollectionsByUserId(
       userId = publisherId
-    ) returns List(collection).point[ConnectionIO]
+    ) returns List(collectionWithSubscriptions).point[ConnectionIO]
 
     collectionPersistenceServices.getTopCollectionsByCategory(
       category   = category,
@@ -91,7 +91,7 @@ trait SharedCollectionProcessesSpecification
 
     collectionPersistenceServices.getCollectionsByUserId(
       userId = subscriberId
-    ) returns List[SharedCollectionServices]().point[ConnectionIO]
+    ) returns List[SharedCollectionWithAggregatedInfo]().point[ConnectionIO]
 
     collectionPersistenceServices.updateCollectionInfo(
       id    = collectionId,
@@ -184,7 +184,7 @@ class SharedCollectionProcessesSpec
   "getPublishedCollections" should {
 
     "return a list of Shared collections of the publisher user" in new SharedCollectionSuccessfulScope {
-      val response = GetCollectionsResponse(List(sharedCollectionWithAppsInfo))
+      val response = GetCollectionsResponse(List(sharedCollectionWithAppsInfoAndSubscriptions))
       val collectionsInfo = sharedCollectionProcesses.getPublishedCollections(
         userId     = publisherId,
         authParams = authParams

--- a/modules/processes/src/test/scala/com/fortysevendeg/ninecards/processes/TestData.scala
+++ b/modules/processes/src/test/scala/com/fortysevendeg/ninecards/processes/TestData.scala
@@ -7,7 +7,7 @@ import com.fortysevendeg.ninecards.processes.ProcessesExceptions.SharedCollectio
 import com.fortysevendeg.ninecards.processes.messages.ApplicationMessages.AuthParams
 import com.fortysevendeg.ninecards.processes.messages.SharedCollectionMessages._
 import com.fortysevendeg.ninecards.services.free.domain.Firebase.{ NotificationIndividualResult, NotificationResponse }
-import com.fortysevendeg.ninecards.services.free.domain.{ Category, Installation, PackageName, SharedCollectionPackage, SharedCollectionSubscription, SharedCollection ⇒ SharedCollectionServices }
+import com.fortysevendeg.ninecards.services.free.domain.{ Category, Installation, PackageName, SharedCollectionPackage, SharedCollectionSubscription, SharedCollectionWithAggregatedInfo, SharedCollection ⇒ SharedCollectionServices }
 import com.fortysevendeg.ninecards.services.free.domain.GooglePlay.{ AppsInfo, AppInfo ⇒ AppInfoServices }
 import com.fortysevendeg.ninecards.services.persistence.SharedCollectionPersistenceServices.{ SharedCollectionData ⇒ SharedCollectionDataServices }
 import org.joda.time.{ DateTime, DateTimeZone }
@@ -67,6 +67,8 @@ object TestData {
   val stars = 5.0d
 
   val subscriberId = 42L
+
+  val subscriptionsCount = 5L
 
   val success = 1
 
@@ -135,6 +137,11 @@ object TestData {
       category         = category,
       icon             = icon,
       community        = community
+    )
+
+    val collectionWithSubscriptions = SharedCollectionWithAggregatedInfo(
+      sharedCollectionData = collection,
+      subscriptionsCount   = subscriptionsCount
     )
 
     val nonExistentSharedCollection: Option[SharedCollectionServices] = None
@@ -212,12 +219,31 @@ object TestData {
       packages         = packagesName
     )
 
+    val sharedCollectionWithSubscriptions = SharedCollection(
+      publicIdentifier   = publicIdentifier,
+      publishedOn        = new DateTime(publishedOnTimestamp.getTime),
+      author             = author,
+      name               = name,
+      installations      = installations,
+      views              = views,
+      category           = category,
+      icon               = icon,
+      community          = community,
+      packages           = packagesName,
+      subscriptionsCount = Option(subscriptionsCount)
+    )
+
     val sharedCollectionUpdateInfo = SharedCollectionUpdateInfo(
       title = name
     )
 
     val sharedCollectionWithAppsInfo = SharedCollectionWithAppsInfo(
       collection = sharedCollection,
+      appsInfo   = appInfoList
+    )
+
+    val sharedCollectionWithAppsInfoAndSubscriptions = SharedCollectionWithAppsInfo(
+      collection = sharedCollectionWithSubscriptions,
       appsInfo   = appInfoList
     )
 

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/Persistence.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/Persistence.scala
@@ -9,8 +9,14 @@ class Persistence[K: Composite](val supportsSelectForUpdate: Boolean = true) {
   def generateQuery(sql: String): Query0[K] =
     Query[HNil, K](sql).toQuery0(HNil)
 
-  def generateQuery[A: Composite](sql: String, values: A): Query0[K] =
-    Query[A, K](sql).toQuery0(values)
+  class GenerateQuery[L] {
+    def apply[A: Composite](sql: String, values: A)(implicit L: Composite[L]): Query0[L] =
+      Query[A, L](sql).toQuery0(values)
+  }
+
+  def generateQuery = new GenerateQuery[K]
+
+  def generateQueryFor[L] = new GenerateQuery[L]
 
   def generateUpdateWithGeneratedKeys[A: Composite](sql: String, values: A): Update0 =
     Update[A](sql).toUpdate0(values)
@@ -20,8 +26,14 @@ class Persistence[K: Composite](val supportsSelectForUpdate: Boolean = true) {
   def fetchList(sql: String): ConnectionIO[List[K]] =
     Query[HNil, K](sql).toQuery0(HNil).to[List]
 
-  def fetchList[A: Composite](sql: String, values: A): ConnectionIO[List[K]] =
-    Query[A, K](sql).to[List](values)
+  class FetchList[L] {
+    def apply[A: Composite](sql: String, values: A)(implicit K: Composite[L]): ConnectionIO[List[L]] =
+      Query[A, L](sql).to[List](values)
+  }
+
+  def fetchList = new FetchList[K]
+
+  def fetchListAs[L] = new FetchList[L]
 
   def fetchOption[A: Composite](sql: String, values: A): ConnectionIO[Option[K]] =
     Query[A, K](sql).option(values)

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/SharedCollectionPersistenceServices.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/SharedCollectionPersistenceServices.scala
@@ -30,8 +30,8 @@ class SharedCollectionPersistenceServices(
   def getCollectionByPublicIdentifier(publicIdentifier: String): ConnectionIO[Option[SharedCollection]] =
     collectionPersistence.fetchOption(CollectionQueries.getByPublicIdentifier, publicIdentifier)
 
-  def getCollectionsByUserId(userId: Long): ConnectionIO[List[SharedCollection]] =
-    collectionPersistence.fetchList(CollectionQueries.getByUser, userId)
+  def getCollectionsByUserId(userId: Long): ConnectionIO[List[SharedCollectionWithAggregatedInfo]] =
+    collectionPersistence.fetchListAs(CollectionQueries.getByUser, userId)
 
   def getLatestCollectionsByCategory(
     category: String,

--- a/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/free/domain/queries/SharedCollectionQueriesSpec.scala
+++ b/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/free/domain/queries/SharedCollectionQueriesSpec.scala
@@ -4,6 +4,7 @@ import java.sql.Timestamp
 import java.time.LocalDateTime
 
 import com.fortysevendeg.ninecards.services.free.domain.SharedCollection.Queries._
+import com.fortysevendeg.ninecards.services.free.domain.SharedCollectionWithAggregatedInfo
 import com.fortysevendeg.ninecards.services.persistence.DomainDatabaseContext
 import com.fortysevendeg.ninecards.services.persistence.SharedCollectionPersistenceServices.SharedCollectionData
 import doobie.contrib.specs2.analysisspec.AnalysisSpec
@@ -48,10 +49,11 @@ class SharedCollectionQueriesSpec
   )
   check(getCollectionByPublicIdentifierQuery)
 
-  val getCollectionsByUserQuery = collectionPersistence.generateQuery(
-    sql    = getByUser,
-    values = userId
-  )
+  val getCollectionsByUserQuery =
+    collectionPersistence.generateQueryFor[SharedCollectionWithAggregatedInfo](
+      sql    = getByUser,
+      values = userId
+    )
   check(getCollectionsByUserQuery)
 
   val getLatestCollectionsByCategoryQuery = collectionPersistence.generateQuery(

--- a/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/SharedCollectionPersistenceServicesSpec.scala
+++ b/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/SharedCollectionPersistenceServicesSpec.scala
@@ -234,12 +234,12 @@ class SharedCollectionPersistenceServicesSpec
 
         val (ownerId, owned) = setupTrans.transactAndRun
 
-        val response: List[SharedCollection] =
+        val response: List[SharedCollectionWithAggregatedInfo] =
           collectionPersistenceServices
             .getCollectionsByUserId(ownerId)
             .transactAndRun
 
-        (response map (_.id)) must containTheSameElementsAs(owned)
+        (response map (_.sharedCollectionData.id)) must containTheSameElementsAs(owned)
       }
     }
   }


### PR DESCRIPTION
This PR adds an optional field into shared collections responses that indicates the number of subscriptions associated to a collections. This field will be only set for the response of the endpoint that returns the collections published by an user.

It closes 47deg/nine-cards-v2#730

@diesalbla Could you take a look please? Thanks
