### PR TITLE
9C-564: Adds a new service to order the device apps by ranking

### DIFF
--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/domain/Ranking.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/free/domain/Ranking.scala
@@ -59,6 +59,10 @@ object rankings {
     ranking: Int
   )
 
+  case class DeviceApp(packageName: String)
+
+  case class RankedApp(packageName: String, category: String, ranking: Option[Int])
+
   object Queries {
 
     val allFields = List("packageName", "category", "ranking")
@@ -88,6 +92,29 @@ object rankings {
 
     def deleteBy(scope: GeoScope): String =
       s"delete from ${tableOf(scope)}"
+
+    def createDeviceAppsTemporaryTableSql(tableName: String) =
+      s"""
+         |CREATE TEMP TABLE $tableName(
+         |  packagename character varying(256) NOT NULL,
+         |  PRIMARY KEY (packagename)
+         |)
+       """.stripMargin
+
+    def dropDeviceAppsTemporaryTableSql(tableName: String) = s"DROP TABLE $tableName"
+
+    def insertDeviceApps(tableName: String) =
+      s"""
+         |INSERT INTO $tableName(packageName)
+         |VALUES (?)
+       """.stripMargin
+
+    def getRankedApps(scope: GeoScope, tableName: String) =
+      s"""
+         |SELECT A.packagename, R.category, R.ranking
+         |FROM ${tableOf(scope)} as R INNER JOIN $tableName as A ON R.packagename=A.packagename
+         |ORDER BY R.category, R.ranking
+       """.stripMargin
   }
 
 }

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/Persistence.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/Persistence.scala
@@ -23,11 +23,11 @@ class Persistence[K: Composite](val supportsSelectForUpdate: Boolean = true) {
 
   def generateUpdate(sql: String): Update0 = Update0(sql, None)
 
-  def fetchList(sql: String): ConnectionIO[List[K]] =
-    Query[HNil, K](sql).toQuery0(HNil).to[List]
-
   class FetchList[L] {
-    def apply[A: Composite](sql: String, values: A)(implicit K: Composite[L]): ConnectionIO[List[L]] =
+    def apply(sql: String)(implicit L: Composite[L]): ConnectionIO[List[L]] =
+      Query[HNil, L](sql).toQuery0(HNil).to[List]
+
+    def apply[A: Composite](sql: String, values: A)(implicit L: Composite[L]): ConnectionIO[List[L]] =
       Query[A, L](sql).to[List](values)
   }
 

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/RankingPersistenceServices.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/persistence/RankingPersistenceServices.scala
@@ -1,8 +1,12 @@
 package com.fortysevendeg.ninecards.services.persistence
 
+import java.security.MessageDigest
+import java.util.UUID
+
 import doobie.imports._
-import com.fortysevendeg.ninecards.services.free.domain.{ Category, PackageName }
+import com.fortysevendeg.ninecards.services.free.domain.Category
 import com.fortysevendeg.ninecards.services.free.domain.rankings._
+
 import scalaz.std.iterable._
 
 object rankings {
@@ -10,6 +14,8 @@ object rankings {
   class Services(persistence: Persistence[Entry]) {
 
     import CustomComposite._
+
+    val digest = MessageDigest.getInstance("MD5")
 
     def getRanking(scope: GeoScope): ConnectionIO[Ranking] = {
       def fromEntries(entries: List[Entry]): Ranking = {
@@ -35,6 +41,22 @@ object rankings {
       } yield (ins, del)
     }
 
+    def getRankedDeviceApps(scope: GeoScope, deviceApps: List[DeviceApp]): ConnectionIO[List[RankedApp]] = {
+      val deviceAppTableName = generateTableName
+
+      for {
+        _ ← persistence.update(Queries.createDeviceAppsTemporaryTableSql(deviceAppTableName))
+        _ ← persistence.updateMany(Queries.insertDeviceApps(deviceAppTableName), deviceApps.distinct)
+        rankedApps ← persistence.fetchListAs[RankedApp](Queries.getRankedApps(scope, deviceAppTableName))
+        _ ← persistence.update(Queries.dropDeviceAppsTemporaryTableSql(deviceAppTableName))
+      } yield rankedApps
+    }
+
+    private[this] def generateTableName = {
+      val text = UUID.randomUUID().toString
+      val hash = digest.digest(text.getBytes).map("%02x".format(_)).mkString
+      s"device_apps_$hash"
+    }
   }
 
   object Services {

--- a/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/free/domain/queries/RankingQueriesSpec.scala
+++ b/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/free/domain/queries/RankingQueriesSpec.scala
@@ -16,6 +16,10 @@ class RankingQueriesSpec
 
   val data: Entry = Entry(PackageName("hammer"), Category.TOOLS, 17)
 
+  val deviceAppData: DeviceApp = DeviceApp("com.package.name")
+
+  val temporaryTableName = "device_apps"
+
   def getBy(scope: GeoScope): Query0[Entry] =
     rankingPersistence.generateQuery(Queries.getBy(scope))
 
@@ -41,5 +45,15 @@ class RankingQueriesSpec
   Country.values foreach { c ⇒ check(insertBy(CountryScope(c))) }
   Continent.values foreach { c ⇒ check(insertBy(ContinentScope(c))) }
   check(insertBy(WorldScope))
+
+  val createDeviceAppsTableQuery = rankingPersistence.generateUpdate(
+    sql = Queries.createDeviceAppsTemporaryTableSql(temporaryTableName)
+  )
+  check(createDeviceAppsTableQuery)
+
+  val dropDeviceAppsTableQuery = rankingPersistence.generateUpdate(
+    sql = Queries.dropDeviceAppsTemporaryTableSql(temporaryTableName)
+  )
+  check(dropDeviceAppsTableQuery)
 
 }

--- a/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/NineCardsScalacheckGen.scala
+++ b/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/NineCardsScalacheckGen.scala
@@ -162,4 +162,8 @@ trait NineCardsScalacheckGen {
 
   implicit val abRanking: Arbitrary[Ranking] = Arbitrary(genRanking)
 
+  val genDeviceApp: Gen[DeviceApp] = genPackage map (p ⇒ DeviceApp(p.name))
+
+  implicit val abDeviceApp: Arbitrary[DeviceApp] = Arbitrary(genDeviceApp)
+
 }

--- a/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/RankingPersistenceServicesSpec.scala
+++ b/modules/services/src/test/scala/com/fortysevendeg/ninecards/services/persistence/RankingPersistenceServicesSpec.scala
@@ -93,4 +93,45 @@ class RankingPersistenceServicesSpec
     }
   }
 
+  "getRankedApp" should {
+
+    "return an empty list of ranked apps if the table is empty" in {
+      prop { (scope: GeoScope, deviceApps: List[DeviceApp]) ⇒
+        val rankedApps = rankingPersistenceServices
+          .getRankedDeviceApps(scope, deviceApps)
+          .transactAndRun
+
+        rankedApps must beEmpty
+      }
+    }
+
+    "return an empty list of ranked apps if an empty list of device apps is given" in {
+      prop { scope: GeoScope ⇒
+        val rankedApps = rankingPersistenceServices
+          .getRankedDeviceApps(scope, Nil)
+          .transactAndRun
+
+        rankedApps must beEmpty
+      }
+    }
+
+    "return a list of ranked apps for the given list of device apps" in {
+      prop { (scope: GeoScope, ranking: Ranking) ⇒
+        rankingPersistenceServices
+          .setRanking(scope, ranking)
+          .transactAndRun
+
+        val deviceApps = ranking.categories.values
+          .flatMap(_.ranking)
+          .collect { case p if p.name.length > 10 ⇒ DeviceApp(p.name) }
+          .toList
+
+        val rankedApps = rankingPersistenceServices
+          .getRankedDeviceApps(scope, deviceApps)
+          .transactAndRun
+
+        rankedApps must haveSize(be_>=(deviceApps.size))
+      }
+    }
+  }
 }


### PR DESCRIPTION
This pull request adds a new service to get the apps installed in the user device ordered by ranking.

To do that, a temporary table is created and populated with the package name of the apps. After performing an inner join, the results are returned and the temporary table is dropped.

@diesalbla Could you take a look please? Thanks
