### PR TITLE
9C-788: Enables debug mode

### DIFF
--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -16,6 +16,8 @@ http {
 
 ninecards.backend {
 
+  debugMode = false
+
   firebase {
     authorizationKey = ""
     authorizationKey = ${?NINECARDS_FIREBASE_AUTH_KEY}

--- a/modules/api/src/main/resources/localhost.conf
+++ b/modules/api/src/main/resources/localhost.conf
@@ -7,3 +7,7 @@ db {
     password = "ninecards_pass"
   }
 }
+
+ninecards.backend {
+  debugMode = true
+}

--- a/modules/processes/src/test/scala/com/fortysevendeg/ninecards/processes/utils/DummyNineCardsConfig.scala
+++ b/modules/processes/src/test/scala/com/fortysevendeg/ninecards/processes/utils/DummyNineCardsConfig.scala
@@ -14,7 +14,7 @@ trait DummyNineCardsConfig {
   val nineCardsSecretKey = "b91064c433a3d4723a622869273bf0d8"
   val nineCardsSalt = "ca349dde5a53d225eeb17074858465d5"
 
-  val dummyConfigHocon =
+  def dummyConfigHocon(debugMode: Boolean) =
     s"""
        |db {
        |  default {
@@ -24,10 +24,15 @@ trait DummyNineCardsConfig {
        |    password = "$dbDefaultPassword"
        |  }
        |}
+       |ninecards.backend {
+       |  debugMode = $debugMode
+       |}
        |ninecards.secretKey = "$nineCardsSecretKey"
        |ninecards.salt = "$nineCardsSalt"
      """.stripMargin
 
-  implicit val dummyConfig = new NineCardsConfig(Option(dummyConfigHocon))
+  def dummyConfig(debugMode: Boolean) = new NineCardsConfig(Option(dummyConfigHocon(debugMode)))
+
+  implicit val config = dummyConfig(debugMode = false)
 
 }

--- a/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/common/NineCardsConfig.scala
+++ b/modules/services/src/main/scala/com/fortysevendeg/ninecards/services/common/NineCardsConfig.scala
@@ -7,6 +7,9 @@ class NineCardsConfig(hocon: Option[String] = None) {
 
   val config = hocon.fold(ConfigFactory.load)(ConfigFactory.parseString)
 
+  def getSysPropKeyAsBoolean(key: String): Option[Boolean] =
+    sys.props.get(key).map(_.toBoolean)
+
   def getSysPropKeyAsInt(key: String): Option[Int] =
     sys.props.get(key).map(_.toInt)
 
@@ -21,6 +24,12 @@ class NineCardsConfig(hocon: Option[String] = None) {
   def getOptionalString(
     key: String
   ) = sys.props.get(key).fold(config.getOptionalString(key))(Option(_))
+
+  def getBoolean(key: String) = getSysPropKeyAsBoolean(key).getOrElse(config.getBoolean(key))
+
+  def getOptionalBoolean(
+    key: String
+  ) = getSysPropKeyAsBoolean(key).fold(config.getOptionalBoolean(key))(Option(_))
 }
 
 object NineCardsConfig {
@@ -33,6 +42,8 @@ object NineCardsConfig {
       } else {
         None
       }
+
+    def getOptionalBoolean(path: String): Option[Boolean] = getOptionalValue(path)(config.getBoolean)
 
     def getOptionalInt(path: String): Option[Int] = getOptionalValue(path)(config.getInt)
 


### PR DESCRIPTION
This pull request allows us to enable the debug mode in the `backend` app in order to make easier the QA task.

When the debug mode is enabled, the auth token is not considered during the authentication process, so an empty auth token can be passed.

It closes 47deg/nine-cards-v2#788

@javipacheco @fedefernandez Could you take a look when you have a chance? Thanks!
