### PR TITLE
Reduces the size of the build by removing dependencies

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,6 @@
+modules/api/src/test
+modules/commons/src/test
+modules/googleplay/src/test
+modules/processes/src/test
+modules/services/src/test
+modules/tests

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,17 +4,17 @@ object Dependencies {
   import sbt._
   import sbt.Keys.libraryDependencies
 
-  private def akka(suff: String) = "com.typesafe.akka" %% s"akka${suff}" % Versions.akka
-  private def circe(suff: String) = "io.circe" %% s"circe${suff}" % Versions.circe
+  private def akka(suff: String) = "com.typesafe.akka" %% s"akka$suff" % Versions.akka
+  private def circe(suff: String) = "io.circe" %% s"circe$suff" % Versions.circe
   private def doobie(suff: String) = "org.tpolecat" %% s"doobie$suff" % Versions.doobie exclude("org.scalaz", "*")
-  private def enumeratum(suff: String) = "com.beachape" %% s"enumeratum${suff}" % Versions.enumeratum
-  private def http4s(suff: String) = "org.http4s" %% s"http4s${suff}" % Versions.http4s
-  private def scalaz(suff: String) = "org.scalaz" %% s"scalaz${suff}" % Versions.scalaz
-  private def specs2(suff: String) = "org.specs2" %% s"specs2${suff}" % Versions.specs2 % "test"
-  private def spray(suff: String) = "io.spray" %% s"spray${suff}" % Versions.spray
+  private def enumeratum(suff: String) = "com.beachape" %% s"enumeratum$suff" % Versions.enumeratum
+  private def http4s(suff: String) = "org.http4s" %% s"http4s$suff" % Versions.http4s
+  private def scalaz(suff: String) = "org.scalaz" %% s"scalaz$suff" % Versions.scalaz
+  private def specs2(suff: String) = "org.specs2" %% s"specs2$suff" % Versions.specs2 % "test"
+  private def spray(suff: String) = "io.spray" %% s"spray$suff" % Versions.spray
 
   private val akkaActor = akka("-actor")
-  private val akkaTestKit = akka("-testkit")
+  private val akkaTestKit = akka("-testkit") % "test"
   private val cats = "org.typelevel" %% "cats" % Versions.cats
   private val embeddedRedis = "com.orange.redis-embedded" % "embedded-redis" % Versions.embeddedRedis % "test"
   private val flywaydbCore = "org.flywaydb" % "flyway-core" % Versions.flywaydb
@@ -22,7 +22,7 @@ object Dependencies {
   private val http4sClient = "org.http4s" %% "http4s-blaze-client" % Versions.http4s
   private val jodaConvert = "org.joda" % "joda-convert" % Versions.jodaConvert
   private val jodaTime = "joda-time" % "joda-time" % Versions.jodaTime
-  private val mockserver = "org.mock-server" % "mockserver-netty" % Versions.mockserver
+  private val mockserver = "org.mock-server" % "mockserver-netty" % Versions.mockserver % "test"
   private val newRelic = "com.newrelic.agent.java" % "newrelic-agent" % Versions.newRelic
   private val redisClient = "net.debasishg" %% "redisclient" % Versions.redisClient
   private val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % Versions.scalacheckShapeless % "test"
@@ -45,7 +45,7 @@ object Dependencies {
 
   val apiDeps = Seq(libraryDependencies ++= baseDeps ++ Seq(
     akkaActor,
-    akkaTestKit % "test",
+    akkaTestKit,
     cats % "test",
     circe("-core"),
     circe("-spray"),
@@ -82,17 +82,14 @@ object Dependencies {
     http4s("-circe"),
     jodaConvert,
     jodaTime,
-    mockserver % "test",
-    sprayJson
+    mockserver
   ))
 
   val googleplayDeps = Seq(sbt.Keys.libraryDependencies ++= Seq(
-    akka("-actor"),
     cats,
     circe("-core"),
     circe("-generic"),
     circe("-parser"),
-    circe("-spray"),
     embeddedRedis,
     enumeratum(""),
     enumeratum("-circe"),
@@ -107,9 +104,6 @@ object Dependencies {
     specs2("-matcher-extra"),
     specs2("-mock"),
     specs2("-scalacheck"),
-    spray("-can"),
-    spray("-routing-shapeless2"),
-    sprayTestKit,
     tagSoup
   ))
 }


### PR DESCRIPTION
This pull request fixes a problem that prevents deploying the app in Heroku because of the size of the build.

The PR does a couple of things:
- Removes unnecessary dependencies
- Creates a file called `.slugignore` to exclude all the test code from the build

@diesalbla Could you take a look please? Thanks
