### PR TITLE
9C-930: Checks shared collection ownership

### DIFF
--- a/modules/api/src/main/scala/cards/nine/api/JsonFormats.scala
+++ b/modules/api/src/main/scala/cards/nine/api/JsonFormats.scala
@@ -58,7 +58,7 @@ trait JsonFormats
 
   implicit val appInfoFormat = jsonFormat7(AppInfo)
 
-  implicit val apiSharedCollection = jsonFormat12(ApiSharedCollection)
+  implicit val apiSharedCollection = jsonFormat13(ApiSharedCollection)
 
   implicit val apiSharedCollectionList = jsonFormat1(ApiSharedCollectionList)
 

--- a/modules/api/src/main/scala/cards/nine/api/NineCardsApi.scala
+++ b/modules/api/src/main/scala/cards/nine/api/NineCardsApi.scala
@@ -235,7 +235,11 @@ class NineCardsRoutes(
     userContext: UserContext
   ): NineCardsServed[XorApiGetCollectionByPublicId] =
     sharedCollectionProcesses
-      .getCollectionByPublicIdentifier(publicId.value, toAuthParams(googlePlayContext, userContext))
+      .getCollectionByPublicIdentifier(
+        userId           = userContext.userId.value,
+        publicIdentifier = publicId.value,
+        authParams       = toAuthParams(googlePlayContext, userContext)
+      )
       .map(_.map(r ⇒ toApiSharedCollection(r.data)))
 
   private[this] def createCollection(
@@ -280,6 +284,7 @@ class NineCardsRoutes(
   ): NineCardsServed[ApiSharedCollectionList] =
     sharedCollectionProcesses
       .getLatestCollectionsByCategory(
+        userId     = userContext.userId.value,
         category   = category.entryName,
         authParams = toAuthParams(googlePlayContext, userContext),
         pageNumber = pageNumber.value,
@@ -311,6 +316,7 @@ class NineCardsRoutes(
   ): NineCardsServed[ApiSharedCollectionList] =
     sharedCollectionProcesses
       .getTopCollectionsByCategory(
+        userId     = userContext.userId.value,
         category   = category.entryName,
         authParams = toAuthParams(googlePlayContext, userContext),
         pageNumber = pageNumber.value,

--- a/modules/api/src/main/scala/cards/nine/api/converters/Converters.scala
+++ b/modules/api/src/main/scala/cards/nine/api/converters/Converters.scala
@@ -70,6 +70,7 @@ object Converters {
       category         = info.collection.category,
       icon             = info.collection.icon,
       community        = info.collection.community,
+      owned            = info.collection.owned,
       packages         = info.collection.packages,
       appsInfo         = info.appsInfo,
       subscriptions    = info.collection.subscriptionsCount

--- a/modules/api/src/main/scala/cards/nine/api/messages/SharedCollectionMessages.scala
+++ b/modules/api/src/main/scala/cards/nine/api/messages/SharedCollectionMessages.scala
@@ -32,6 +32,7 @@ object SharedCollectionMessages {
     category: String,
     icon: String,
     community: Boolean,
+    owned: Boolean,
     packages: List[String],
     appsInfo: List[AppInfo],
     subscriptions: Option[Long] = None

--- a/modules/api/src/test/scala/cards/nine/api/NineCardsApiSpec.scala
+++ b/modules/api/src/test/scala/cards/nine/api/NineCardsApiSpec.scala
@@ -74,7 +74,7 @@ trait NineCardsApiSpecification
     sharedCollectionProcesses.createCollection(any) returns
       Free.pure(Messages.createOrUpdateCollectionResponse)
 
-    sharedCollectionProcesses.getCollectionByPublicIdentifier(any[String], any) returns
+    sharedCollectionProcesses.getCollectionByPublicIdentifier(any, any[String], any) returns
       Free.pure(Messages.getCollectionByPublicIdentifierResponse.right)
 
     sharedCollectionProcesses.subscribe(any[String], any[Long]) returns
@@ -83,7 +83,7 @@ trait NineCardsApiSpecification
     sharedCollectionProcesses.unsubscribe(any[String], any[Long]) returns
       Free.pure(Messages.unsubscribeResponse.right)
 
-    sharedCollectionProcesses.getLatestCollectionsByCategory(any, any, any, any) returns
+    sharedCollectionProcesses.getLatestCollectionsByCategory(any, any, any, any, any) returns
       Free.pure(Messages.getCollectionsResponse)
 
     sharedCollectionProcesses.getPublishedCollections(any[Long], any) returns
@@ -92,7 +92,7 @@ trait NineCardsApiSpecification
     sharedCollectionProcesses.getSubscriptionsByUser(any) returns
       Free.pure(Messages.getSubscriptionsByUserResponse)
 
-    sharedCollectionProcesses.getTopCollectionsByCategory(any, any, any, any) returns
+    sharedCollectionProcesses.getTopCollectionsByCategory(any, any, any, any, any) returns
       Free.pure(Messages.getCollectionsResponse)
 
     sharedCollectionProcesses.updateCollection(any, any, any) returns
@@ -127,7 +127,7 @@ trait NineCardsApiSpecification
       requestUri   = any[String]
     ) returns Free.pure(None)
 
-    sharedCollectionProcesses.getCollectionByPublicIdentifier(any[String], any) returns
+    sharedCollectionProcesses.getCollectionByPublicIdentifier(any, any[String], any) returns
       Free.pure(sharedCollectionNotFoundException.left)
 
     sharedCollectionProcesses.subscribe(any[String], any[Long]) returns
@@ -161,10 +161,10 @@ trait NineCardsApiSpecification
     sharedCollectionProcesses.createCollection(any) returns
       Free.pure(Messages.createOrUpdateCollectionResponse)
 
-    sharedCollectionProcesses.getCollectionByPublicIdentifier(any[String], any) returns
+    sharedCollectionProcesses.getCollectionByPublicIdentifier(any, any[String], any) returns
       Free.pure(Messages.getCollectionByPublicIdentifierResponse.right)
 
-    sharedCollectionProcesses.getLatestCollectionsByCategory(any, any, any, any) returns
+    sharedCollectionProcesses.getLatestCollectionsByCategory(any, any, any, any, any) returns
       Free.pure(Messages.getCollectionsResponse)
 
     sharedCollectionProcesses.getPublishedCollections(any[Long], any) returns
@@ -173,7 +173,7 @@ trait NineCardsApiSpecification
     sharedCollectionProcesses.getSubscriptionsByUser(any) returns
       Free.pure(Messages.getSubscriptionsByUserResponse)
 
-    sharedCollectionProcesses.getTopCollectionsByCategory(any, any, any, any) returns
+    sharedCollectionProcesses.getTopCollectionsByCategory(any, any, any, any, any) returns
       Free.pure(Messages.getCollectionsResponse)
 
     sharedCollectionProcesses.subscribe(any[String], any[Long]) returns

--- a/modules/api/src/test/scala/cards/nine/api/TestData.scala
+++ b/modules/api/src/test/scala/cards/nine/api/TestData.scala
@@ -58,6 +58,8 @@ object TestData {
 
   val now = DateTime.now
 
+  val owned = true
+
   val packagesName = List(
     "earth.europe.italy",
     "earth.europe.unitedKingdom",
@@ -138,6 +140,7 @@ object TestData {
       category         = category,
       icon             = icon,
       community        = community,
+      owned            = owned,
       packages         = packagesName
     )
 

--- a/modules/processes/src/main/scala/cards/nine/processes/converters/Converters.scala
+++ b/modules/processes/src/main/scala/cards/nine/processes/converters/Converters.scala
@@ -67,17 +67,18 @@ object Converters {
       community        = data.community
     )
 
-  def toSharedCollection: (BaseSharedCollection, List[String]) ⇒ SharedCollection = {
-    case (collection: SharedCollectionWithAggregatedInfo, packages) ⇒
-      toSharedCollection(collection.sharedCollectionData, packages, Option(collection.subscriptionsCount))
-    case (collection: SharedCollectionServices, packages) ⇒
-      toSharedCollection(collection, packages, None)
+  def toSharedCollection: (BaseSharedCollection, List[String], Long) ⇒ SharedCollection = {
+    case (collection: SharedCollectionWithAggregatedInfo, packages, userId) ⇒
+      toSharedCollection(collection.sharedCollectionData, packages, Option(collection.subscriptionsCount), userId)
+    case (collection: SharedCollectionServices, packages, userId) ⇒
+      toSharedCollection(collection, packages, None, userId)
   }
 
   def toSharedCollection(
     collection: SharedCollectionServices,
     packages: List[String],
-    subscriptionCount: Option[Long]
+    subscriptionCount: Option[Long],
+    userId: Long
   ) =
     SharedCollection(
       publicIdentifier   = collection.publicIdentifier,
@@ -89,6 +90,7 @@ object Converters {
       category           = collection.category,
       icon               = collection.icon,
       community          = collection.community,
+      owned              = collection.userId.fold(false)(user ⇒ user == userId),
       packages           = packages,
       subscriptionsCount = subscriptionCount
     )

--- a/modules/processes/src/main/scala/cards/nine/processes/messages/SharedCollectionMessages.scala
+++ b/modules/processes/src/main/scala/cards/nine/processes/messages/SharedCollectionMessages.scala
@@ -43,6 +43,7 @@ object SharedCollectionMessages {
     category: String,
     icon: String,
     community: Boolean,
+    owned: Boolean,
     packages: List[String],
     subscriptionsCount: Option[Long] = None
   )

--- a/modules/processes/src/test/scala/cards/nine/processes/SharedCollectionProcessesSpec.scala
+++ b/modules/processes/src/test/scala/cards/nine/processes/SharedCollectionProcessesSpec.scala
@@ -140,6 +140,7 @@ class SharedCollectionProcessesSpec
     "return a valid shared collection info when the shared collection exists" in
       new SharedCollectionSuccessfulScope {
         val collectionInfo = sharedCollectionProcesses.getCollectionByPublicIdentifier(
+          userId           = publisherId,
           publicIdentifier = publicIdentifier,
           authParams       = authParams
         )
@@ -150,6 +151,7 @@ class SharedCollectionProcessesSpec
     "return a SharedCollectionNotFoundException when the shared collection doesn't exist" in
       new SharedCollectionUnsuccessfulScope {
         val collectionInfo = sharedCollectionProcesses.getCollectionByPublicIdentifier(
+          userId           = publisherId,
           publicIdentifier = publicIdentifier,
           authParams       = authParams
         )
@@ -163,6 +165,7 @@ class SharedCollectionProcessesSpec
     "return a list of Shared collections of the given category" in new SharedCollectionSuccessfulScope {
       val response = GetCollectionsResponse(List(sharedCollectionWithAppsInfo))
       val collectionsInfo = sharedCollectionProcesses.getLatestCollectionsByCategory(
+        userId     = publisherId,
         category   = category,
         authParams = authParams,
         pageNumber = pageNumber,
@@ -212,6 +215,7 @@ class SharedCollectionProcessesSpec
     "return a list of Shared collections of the given category" in new SharedCollectionSuccessfulScope {
       val response = GetCollectionsResponse(List(sharedCollectionWithAppsInfo))
       val collectionsInfo = sharedCollectionProcesses.getTopCollectionsByCategory(
+        userId     = publisherId,
         category   = category,
         authParams = authParams,
         pageNumber = pageNumber,

--- a/modules/processes/src/test/scala/cards/nine/processes/TestData.scala
+++ b/modules/processes/src/test/scala/cards/nine/processes/TestData.scala
@@ -235,6 +235,7 @@ object TestData {
       category         = category,
       icon             = icon,
       community        = community,
+      owned            = true,
       packages         = packagesName
     )
 
@@ -248,6 +249,7 @@ object TestData {
       category           = category,
       icon               = icon,
       community          = community,
+      owned              = true,
       packages           = packagesName,
       subscriptionsCount = Option(subscriptionsCount)
     )


### PR DESCRIPTION
This pull request allows us to check the ownership of a shared collection and add a new field to the response.

It closes 47deg/nine-cards-v2#930

@diesalbla Could you review at your convenience? Thanks!
