### PR TITLE
Remove GooglePlay old stuff

### DIFF
--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/domain/Domain.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/domain/Domain.scala
@@ -20,20 +20,6 @@ case class AppRequest(
 
 case class PackageList(items: List[String]) extends AnyVal
 
-case class PackageDetails(errors: List[String], items: List[Item])
-
-case class Item(docV2: DocV2)
-case class DocV2(title: String, creator: String, docid: String, details: Details, aggregateRating: AggregateRating, image: List[Image], offer: List[Offer])
-case class Details(appDetails: AppDetails)
-case class AppDetails(appCategory: List[String], numDownloads: String, permission: List[String])
-case class AggregateRating(ratingsCount: Long, oneStarRatings: Long, twoStarRatings: Long, threeStarRatings: Long, fourStarRatings: Long, fiveStarRatings: Long, starRating: Double) // commentcount?
-
-object AggregateRating {
-  val Zero = AggregateRating(0, 0, 0, 0, 0, 0, 0.0)
-}
-case class Image(imageType: Long, imageUrl: String) // todo check which fields are necessary here
-case class Offer(offerType: Long) // todo check which fields are necessary here
-
 case class InfoError(message: String) extends AnyVal
 
 sealed trait PriceFilter extends EnumEntry

--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/googleapi/Converters.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/googleapi/Converters.scala
@@ -1,6 +1,6 @@
 package cards.nine.googleplay.service.free.interpreter.googleapi
 
-import cards.nine.googleplay.domain.{ DocV2 ⇒ DomainDocV2, _ }
+import cards.nine.googleplay.domain._
 import cards.nine.googleplay.proto.GooglePlay.{ ListResponse, DocV2 }
 import cats.data.Xor
 import cats.instances.list._
@@ -54,36 +54,7 @@ object Converters {
       categories  = categories
     )
 
-    def toItem(): Item = {
-      val details = docV2.getDetails
-      val appDetails = details.getAppDetails
-      val agg = docV2.getAggregateRating
-
-      Item(DomainDocV2(
-        title           = title,
-        creator         = docV2.getCreator,
-        docid           = docid,
-        details         = Details(appDetails = AppDetails(
-          appCategory  = appDetails.getAppCategoryList.toList,
-          numDownloads = appDetails.getNumDownloads,
-          permission   = appDetails.getPermissionList.toList
-        )),
-        aggregateRating = AggregateRating(
-          ratingsCount     = agg.getRatingsCount,
-          oneStarRatings   = agg.getOneStarRatings,
-          twoStarRatings   = agg.getTwoStarRatings,
-          threeStarRatings = agg.getThreeStarRatings,
-          fourStarRatings  = agg.getFourStarRatings,
-          fiveStarRatings  = agg.getFiveStarRatings,
-          starRating       = agg.getStarRating
-        ),
-        image           = Nil,
-        offer           = Nil
-      ))
-    }
   }
-
-  def toItem(docV2: DocV2): Item = new WrapperDocV2(docV2).toItem
 
   def toFullCard(docV2: DocV2): FullCard = new WrapperDocV2(docV2).toFullCard
 

--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/googleapi/Interpreter.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/googleapi/Interpreter.scala
@@ -1,7 +1,7 @@
 package cards.nine.googleplay.service.free.interpreter.googleapi
 
 import cards.nine.commons.TaskInstances._
-import cards.nine.googleplay.domain.{ Details ⇒ _, _ }
+import cards.nine.googleplay.domain._
 import cards.nine.googleplay.domain.apigoogle._
 import cards.nine.googleplay.proto.GooglePlay.{ BulkDetailsRequest, DocV2, ResponseWrapper }
 import cards.nine.googleplay.service.free.algebra.GoogleApi._

--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/webscraper/Converters.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/webscraper/Converters.scala
@@ -109,34 +109,7 @@ object GooglePlayPageParser {
 
     def parseCard(): Option[FullCard] = parseCardAux.headOption
 
-    def parseItem(): Option[Item] =
-      for { /*Option*/
-        title: String ← getTitle().headOption
-        docId: String ← getDocId().headOption
-        downloads ← getDownloads().headOption
-      } yield Item(
-        DocV2(
-          title           = title,
-          creator         = "",
-          docid           = docId,
-          details         = Details(appDetails = AppDetails(
-            appCategory  = getCategories().toList,
-            numDownloads = downloads,
-            permission   = Nil
-          )),
-          aggregateRating = AggregateRating.Zero,
-          image           = Nil,
-          offer           = Nil
-        )
-      )
-
   }
-
-  def parseItem(byteVector: ByteVector): Option[Item] =
-    parseItemAux(decodeNode(byteVector))
-
-  def parseItemAux(document: Node): Option[Item] =
-    new NodeWrapper(document).parseItem()
 
   def parseCard(byteVector: ByteVector): Option[FullCard] =
     parseCardAux(decodeNode(byteVector))

--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/webscraper/Http4sGooglePlayWebScraper.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/webscraper/Http4sGooglePlayWebScraper.scala
@@ -43,14 +43,6 @@ class Http4sGooglePlayWebScraper(serverUrl: String, client: Client) {
     }
   }
 
-  def getItem(appRequest: AppRequest): Task[Xor[String, Item]] = {
-    lazy val failed = appRequest.packageName.value
-    runRequest[String, Item](appRequest, failed, { bv ⇒
-      GooglePlayPageParser.parseItem(bv)
-        .fold(failed.left[Item])(i ⇒ i.right[String])
-    })
-  }
-
   def getCard(appRequest: AppRequest): Task[Xor[InfoError, FullCard]] = {
     lazy val failed: InfoError = InfoError(appRequest.packageName.value)
     runRequest[InfoError, FullCard](appRequest, failed, { bv ⇒

--- a/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/googleapi/ConvertersSpec.scala
+++ b/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/googleapi/ConvertersSpec.scala
@@ -1,6 +1,6 @@
 package cards.nine.googleplay.service.free.interpreter.googleapi
 
-import cards.nine.googleplay.domain.{ FullCard, FullCardList, Item, Package }
+import cards.nine.googleplay.domain.{ FullCard, FullCardList, Package }
 import cards.nine.googleplay.proto.GooglePlay.{ ResponseWrapper, DocV2, ListResponse }
 import cards.nine.googleplay.service.free.interpreter.TestData.{ fisherPrice, minecraft }
 import java.nio.file.{ Files, Paths }
@@ -22,12 +22,6 @@ class ConvertersSpec extends Specification {
   def getListResponse(rw: ResponseWrapper): ListResponse = rw.getPayload.getListResponse
 
   "From a DocV2 carrying an application's details, it " should {
-
-    "result in an Item to send to the client" in {
-      val docV2: DocV2 = getDetailsResponse(readProtobufFile(fisherPrice.packageName))
-      val item: Item = toItem(docV2)
-      item.docV2.docid must_=== fisherPrice.packageName
-    }
 
     "result in a Card to send to the client" in {
       val docV2: DocV2 = getDetailsResponse(readProtobufFile(fisherPrice.packageName))

--- a/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/webscraper/ConvertersSpec.scala
+++ b/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/webscraper/ConvertersSpec.scala
@@ -22,15 +22,6 @@ class ConvertersSpec extends Specification {
   def failTest(s: String) = throw new RuntimeException(s)
 
   "Parsing the HTML for the play store" should {
-    "result in an Item to send to the client" in {
-      val parsedItem = GooglePlayPageParser
-        .parseItemAux(readHtmlFile(fisherPrice.packageName))
-        .getOrElse(failTest("Item should parse correctly"))
-
-      parsedItem.docV2.details.appDetails.appCategory must_=== fisherPrice.card.categories
-      parsedItem.docV2.docid must_=== fisherPrice.packageName
-      parsedItem.docV2.title must_=== fisherPrice.card.title
-    }
 
     "result in an FullCard to send to the client" in {
       val card = GooglePlayPageParser

--- a/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/webscraper/WebScraperIntegration.scala
+++ b/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/webscraper/WebScraperIntegration.scala
@@ -21,22 +21,6 @@ class InterpretersIntegration extends Specification with WithHttp1Client {
 
     val auth = GoogleAuthParams(AndroidId(""), Token(""), Some(localization))
 
-    "result in an Item for packages that exist" in {
-      val appRequest = AppRequest(fisherPrice.packageObj, auth)
-      val response: Task[Xor[String, Item]] = webClient.getItem(appRequest)
-      val relevantDetails = response.map(_.map { i: Item ⇒
-        (i.docV2.docid, i.docV2.details.appDetails.appCategory, i.docV2.title)
-      })
-      val expected = (fisherPrice.packageName, fisherPrice.card.categories, fisherPrice.card.title)
-      relevantDetails must returnValue(Xor.right(expected))
-    }
-
-    "result in an error state for packages that do not exist" in {
-      val appRequest = AppRequest(nonexisting.packageObj, auth)
-      val response = webClient.getItem(appRequest)
-      response must returnValue(Xor.left(nonexisting.packageName))
-    }
-
     "result in an FullCard for packages that exist" in {
       val appRequest = AppRequest(fisherPrice.packageObj, auth)
       val response: Task[Xor[InfoError, FullCard]] = webClient.getCard(appRequest)

--- a/modules/googleplay/src/test/scala/cards/nine/googleplay/util/ScalaCheck.scala
+++ b/modules/googleplay/src/test/scala/cards/nine/googleplay/util/ScalaCheck.scala
@@ -26,17 +26,11 @@ object ScalaCheck {
   implicit val arbFullCard: Arbitrary[FullCard] =
     ScalaCheck_Aux.arbFullCard
 
-  implicit val arbItem: Arbitrary[Item] =
-    ScalaCheck_Aux.arbItem
-
   implicit val arbString: Arbitrary[String] =
     ScalaCheck_Aux.arbString
 
   implicit val arbGetCardAnswer: Arbitrary[Xor[InfoError, FullCard]] =
     ScalaCheck_Aux.arbGetCardAnswer
-
-  implicit val arbResolveAnswer: Arbitrary[Xor[String, Item]] =
-    ScalaCheck_Aux.arbResolveAnswer
 
   implicit val arbCategory: Arbitrary[Category] =
     ScalaCheck_Aux.arbCategory
@@ -100,37 +94,10 @@ object ScalaCheck_Aux {
 
   val arbFullCard: Arbitrary[FullCard] = Arbitrary(genFullCard)
 
-  val arbItem: Arbitrary[Item] = Arbitrary(for {
-    title ← identifier
-    docid ← identifier
-    appDetails ← listOf(identifier)
-  } yield Item(
-    DocV2(
-      title           = title,
-      creator         = "",
-      docid           = docid,
-      details         = Details(
-        appDetails = AppDetails(
-          appCategory  = appDetails,
-          numDownloads = "",
-          permission   = Nil
-        )
-      ),
-      aggregateRating = AggregateRating.Zero,
-      image           = Nil,
-      offer           = Nil
-    )
-  ))
-
   val arbGetCardAnswer = {
     implicit val app: Arbitrary[FullCard] = arbFullCard
     implicit val fail: Arbitrary[String] = arbString
     implicitly[Arbitrary[Xor[InfoError, FullCard]]]
-  }
-
-  val arbResolveAnswer: Arbitrary[Xor[String, Item]] = {
-    implicit val item: Arbitrary[Item] = arbItem
-    implicitly[Arbitrary[Xor[String, Item]]]
   }
 
 }


### PR DESCRIPTION
Removes domain classes and tests from deprecated endpoints and methods in the Google Play Module. No change in Api. No QA needed. 

@franciscodr 
