### PR TITLE
9C-956: Uses new cache services in card processes

### DIFF
--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/domain/ApiGoogle.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/domain/ApiGoogle.scala
@@ -1,6 +1,6 @@
 package cards.nine.googleplay.domain
 
-import cards.nine.domain.application.Package
+import cards.nine.domain.application.{ FullCard, Package }
 import cards.nine.domain.market.MarketCredentials
 
 package apigoogle {
@@ -11,4 +11,11 @@ package apigoogle {
   case class WrongAuthParams(auth: MarketCredentials) extends Failure
   case class QuotaExceeded(auth: MarketCredentials) extends Failure
   case object GoogleApiServerError extends Failure
+
+  case class ResolvePackagesResult(
+    cachedPackages: List[FullCard],
+    resolvedPackages: List[FullCard],
+    notFoundPackages: List[Package],
+    pendingPackages: List[Package]
+  )
 }

--- a/modules/services/src/test/scala/cards/nine/services/free/interpreter/googleplay/ServicesSpec.scala
+++ b/modules/services/src/test/scala/cards/nine/services/free/interpreter/googleplay/ServicesSpec.scala
@@ -4,8 +4,8 @@ import cards.nine.domain.account.AndroidId
 import cards.nine.domain.application.{ Category, FullCard, FullCardList, Package, PriceFilter }
 import cards.nine.domain.market.{ Localization, MarketCredentials, MarketToken }
 import cards.nine.googleplay.domain._
-import cards.nine.googleplay.processes.getcard.{ FailedResponse, UnknownPackage }
-import cards.nine.googleplay.processes.{ CardsProcesses, Wiring }
+import cards.nine.googleplay.processes.getcard.UnknownPackage
+import cards.nine.googleplay.processes.{ CardsProcesses, ResolveMany, Wiring }
 import cats.data.Xor
 import cats.free.Free
 import org.specs2.matcher.{ DisjunctionMatchers, Matcher, Matchers, XorMatchers }
@@ -103,8 +103,7 @@ class GooglePlayServicesSpec
         cards   = fullCards
       )
 
-      val getCardsResponse: List[Xor[FailedResponse, FullCard]] =
-        (fullCards map Xor.right) ++ (unknownPackageErrors map Xor.left)
+      val resolveManyResponse = ResolveMany.Response(wrongPackages, Nil, fullCards)
     }
   }
 
@@ -143,7 +142,7 @@ class GooglePlayServicesSpec
     "return the list of apps that are valid and those that are wrong" in new BasicScope {
 
       googlePlayProcesses.getCards(packages, AuthData.marketAuth) returns
-        Free.pure(GooglePlayResponses.getCardsResponse)
+        Free.pure(GooglePlayResponses.resolveManyResponse)
 
       val response = services.resolveMany(packages, AuthData.marketAuth, true)
 


### PR DESCRIPTION
This pull request uses the recently created cache batch services in the processes that get info from Redis cache.

It also change the `searchApps` process to use the `bulkDetails` service instead of calling the `details` service for each package.

@fedefernandez Could you review at your convenience please? Thanks!
