### PR TITLE
9C-969: Moves CacheWrapper class to commons

### DIFF
--- a/modules/commons/src/main/scala/cards/nine/commons/CacheWrapper.scala
+++ b/modules/commons/src/main/scala/cards/nine/commons/CacheWrapper.scala
@@ -1,9 +1,7 @@
-package cards.nine.googleplay.service.free.interpreter.cache
+package cards.nine.commons
 
-import com.redis._
+import com.redis.RedisClient
 import com.redis.serialization.{ Format, Parse }
-import io.circe._
-import io.circe.parser._
 
 import scala.annotation.tailrec
 
@@ -54,18 +52,6 @@ class CacheWrapper[Key, Val](client: RedisClient)(implicit f: Format, pk: Parse[
 }
 
 object CacheWrapper {
-
-  implicit def keyParse(implicit dv: Decoder[CacheKey]): Parse[Option[CacheKey]] =
-    Parse(bv ⇒ decode[CacheKey](Parse.Implicits.parseString(bv)).toOption)
-
-  implicit def valParse(implicit dv: Decoder[CacheVal]): Parse[Option[CacheVal]] =
-    Parse(bv ⇒ decode[CacheVal](Parse.Implicits.parseString(bv)).toOption)
-
-  implicit def keyAndValFormat(implicit ek: Encoder[CacheKey], ev: Encoder[CacheVal]): Format =
-    Format {
-      case key: CacheKey ⇒ ek(key).noSpaces
-      case value: CacheVal ⇒ ev(value).noSpaces
-    }
 
   def apply[Key, Val](client: RedisClient)(
     implicit

--- a/modules/commons/src/main/scala/cards/nine/commons/JsonPattern.scala
+++ b/modules/commons/src/main/scala/cards/nine/commons/JsonPattern.scala
@@ -1,0 +1,30 @@
+package cards.nine.commons
+
+sealed trait JsonPattern
+
+case object PStar extends JsonPattern
+
+case object PNull extends JsonPattern
+
+case class PString(value: String) extends JsonPattern
+
+case class PObject(fields: List[(PString, JsonPattern)]) extends JsonPattern
+
+object JsonPattern {
+
+  def print(pattern: JsonPattern): String = pattern match {
+    case PStar ⇒ """ * """.trim
+    case PNull ⇒ """ null """.trim
+    case PString(str) ⇒ s""" "$str" """.trim
+    case PObject(fields) ⇒
+      def printField(field: (PString, JsonPattern)): String = {
+        val key = print(field._1)
+        val value = print(field._2)
+        s""" $key:$value """.trim
+      }
+
+      val fs = fields.map(printField).mkString(",")
+      s""" {$fs} """.trim
+  }
+
+}

--- a/modules/commons/src/test/scala/cards/nine/commons/CacheWrapperSpec.scala
+++ b/modules/commons/src/test/scala/cards/nine/commons/CacheWrapperSpec.scala
@@ -1,8 +1,8 @@
-package cards.nine.googleplay.service.free.interpreter.cache
+package cards.nine.commons
 
 import com.redis.RedisClient
 import com.redis.serialization.{ Format, Parse }
-import io.circe._
+import io.circe.{ Decoder, Encoder }
 import io.circe.generic.semiauto._
 import io.circe.parser._
 import org.scalacheck.{ Arbitrary, Gen }

--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/cache/Model.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/cache/Model.scala
@@ -45,32 +45,3 @@ object CacheEntry {
   def permanent(name: Package, card: FullCard): CacheEntry =
     (CacheKey.permanent(name), CacheVal(Some(card)))
 }
-
-sealed trait JsonPattern
-
-case object PStar extends JsonPattern
-
-case object PNull extends JsonPattern
-
-case class PString(value: String) extends JsonPattern
-
-case class PObject(fields: List[(PString, JsonPattern)]) extends JsonPattern
-
-object JsonPattern {
-
-  def print(pattern: JsonPattern): String = pattern match {
-    case PStar ⇒ """ * """.trim
-    case PNull ⇒ """ null """.trim
-    case PString(str) ⇒ s""" "$str" """.trim
-    case PObject(fields) ⇒
-      def printField(field: (PString, JsonPattern)): String = {
-        val key = print(field._1)
-        val value = print(field._2)
-        s""" $key:$value """.trim
-      }
-
-      val fs = fields.map(printField).mkString(",")
-      s""" {$fs} """.trim
-  }
-
-}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,10 +58,15 @@ object Dependencies {
 
   val commonsDeps = Seq(libraryDependencies ++= Seq(
     cats,
-    scalaz("-concurrent"),
+    circe("-core"),
+    circe("-generic"),
+    circe("-parser"),
+    embeddedRedis,
     enumeratum(""),
     jodaConvert,
     jodaTime,
+    redisClient,
+    scalaz("-concurrent"),
     specs2Core,
     specs2("-scalacheck"),
     scalacheckShapeless,


### PR DESCRIPTION
This pull request moves CacheWrapper utility to `commons` because it will use in two different modules.

@fedefernandez Could you review at your convenience please? Thanks
