### PR TITLE
Changes the response of rank endpoints to maintain the order

### DIFF
--- a/modules/api/src/main/scala/cards/nine/api/JsonFormats.scala
+++ b/modules/api/src/main/scala/cards/nine/api/JsonFormats.scala
@@ -135,9 +135,12 @@ trait JsonFormats
 
   implicit val apiRankAppsByMomentsRequestFormat = jsonFormat3(ApiRankAppsByMomentsRequest)
 
+  implicit val apiRankedAppsByCategoryFormat = jsonFormat2(ApiRankedAppsByCategory)
+
   implicit val apiRankAppsResponseFormat = jsonFormat1(ApiRankAppsResponse)
 
   implicit val apiSearchAppsRequest = jsonFormat3(ApiSearchAppsRequest)
+
   implicit val apiSearchAppsResponse = jsonFormat1(ApiSearchAppsResponse)
 }
 

--- a/modules/api/src/main/scala/cards/nine/api/converters/Converters.scala
+++ b/modules/api/src/main/scala/cards/nine/api/converters/Converters.scala
@@ -7,7 +7,7 @@ import cards.nine.api.messages.SharedCollectionMessages._
 import cards.nine.api.messages.UserMessages._
 import cards.nine.commons.NineCardsService.Result
 import cards.nine.domain.account._
-import cards.nine.domain.analytics.RankedApp
+import cards.nine.domain.analytics.RankedAppsByCategory
 import cards.nine.domain.application.{ FullCard, FullCardList, Package }
 import cards.nine.domain.market.MarketCredentials
 import cards.nine.processes.messages.InstallationsMessages._
@@ -177,10 +177,13 @@ object Converters {
   def toApiSearchAppsResponse(response: FullCardList): ApiSearchAppsResponse =
     ApiSearchAppsResponse(response.cards map toApiRecommendation)
 
-  def toApiRankAppsResponse(result: Result[Map[String, List[RankedApp]]]) =
+  def toApiRankedAppsByCategory(ranking: RankedAppsByCategory) =
+    ApiRankedAppsByCategory(ranking.category, ranking.packages map (_.packageName))
+
+  def toApiRankAppsResponse(result: Result[List[RankedAppsByCategory]]) =
     result.map {
       items ⇒
-        ApiRankAppsResponse(items.mapValues(apps ⇒ apps.map(_.packageName)))
+        ApiRankAppsResponse(items map toApiRankedAppsByCategory)
     }
 
   def toDeviceAppList(items: List[Package]) = items map DeviceApp.apply

--- a/modules/api/src/main/scala/cards/nine/api/messages/GooglePlayMessages.scala
+++ b/modules/api/src/main/scala/cards/nine/api/messages/GooglePlayMessages.scala
@@ -53,7 +53,9 @@ object GooglePlayMessages {
     moments: List[String]
   )
 
-  case class ApiRankAppsResponse(items: Map[String, List[Package]])
+  case class ApiRankedAppsByCategory(category: String, packages: List[Package])
+
+  case class ApiRankAppsResponse(items: List[ApiRankedAppsByCategory])
 
   case class ApiSearchAppsRequest(
     query: String,

--- a/modules/api/src/test/scala/cards/nine/api/TestData.scala
+++ b/modules/api/src/test/scala/cards/nine/api/TestData.scala
@@ -7,7 +7,7 @@ import cards.nine.api.messages.SharedCollectionMessages._
 import cards.nine.api.messages.UserMessages.ApiLoginRequest
 import cards.nine.api.messages.{ rankings ⇒ Api }
 import cards.nine.domain.account._
-import cards.nine.domain.analytics.RankedApp
+import cards.nine.domain.analytics.RankedAppsByCategory
 import cards.nine.domain.application.{ Category, FullCardList, Package }
 import cards.nine.processes.ProcessesExceptions.SharedCollectionNotFoundException
 import cards.nine.processes.messages.InstallationsMessages._
@@ -179,7 +179,7 @@ object TestData {
       moments  = moments
     )
 
-    val getRankedAppsResponse = Map.empty[String, List[RankedApp]]
+    val getRankedAppsResponse = List.empty[RankedAppsByCategory]
 
     val getRecommendationsByCategoryResponse = FullCardList(Nil, Nil)
 

--- a/modules/commons/src/main/scala/cards/nine/domain/analytics/Analytics.scala
+++ b/modules/commons/src/main/scala/cards/nine/domain/analytics/Analytics.scala
@@ -35,4 +35,5 @@ package analytics {
 
   case class RankedApp(packageName: Package, category: String, position: Option[Int])
 
+  case class RankedAppsByCategory(category: String, packages: List[RankedApp])
 }

--- a/modules/commons/src/main/scala/cards/nine/domain/application/Category.scala
+++ b/modules/commons/src/main/scala/cards/nine/domain/application/Category.scala
@@ -58,4 +58,40 @@ object Category extends Enum[Category] {
   case object GAME_WORD extends Category
 
   val values = super.findValues
+
+  val sortedValues = List(
+    COMMUNICATION,
+    SOCIAL,
+    PRODUCTIVITY,
+    PHOTOGRAPHY,
+    ENTERTAINMENT,
+    GAME,
+    VIDEO_PLAYERS,
+    MAPS_AND_NAVIGATION,
+    MUSIC_AND_AUDIO,
+    NEWS_AND_MAGAZINES,
+    LIFESTYLE,
+    HEALTH_AND_FITNESS,
+    SPORTS,
+    SHOPPING,
+    TRAVEL_AND_LOCAL,
+    FINANCE,
+    BOOKS_AND_REFERENCE,
+    EDUCATION,
+    ART_AND_DESIGN,
+    FOOD_AND_DRINK,
+    AUTO_AND_VEHICLES,
+    BEAUTY,
+    BUSINESS,
+    COMICS,
+    DATING,
+    EVENTS,
+    HOUSE_AND_HOME,
+    LIBRARIES_AND_DEMO,
+    MEDICAL,
+    PARENTING,
+    PERSONALIZATION,
+    TOOLS,
+    WEATHER
+  ) map (_.entryName)
 }

--- a/modules/processes/src/test/scala/cards/nine/processes/RankingProcessesSpec.scala
+++ b/modules/processes/src/test/scala/cards/nine/processes/RankingProcessesSpec.scala
@@ -2,7 +2,7 @@ package cards.nine.processes
 
 import cards.nine.commons.NineCardsErrors.NineCardsError
 import cards.nine.commons.NineCardsService
-import cards.nine.domain.analytics.{ RankedApp, WorldScope }
+import cards.nine.domain.analytics.{ RankedApp, RankedAppsByCategory, WorldScope }
 import cards.nine.processes.NineCardsServices._
 import cards.nine.processes.TestData.Values._
 import cards.nine.processes.TestData.rankings._
@@ -35,6 +35,10 @@ trait RankingsProcessesSpecification
 
     def hasRankingInfo(hasRanking: Boolean): Matcher[RankedApp] = {
       app: RankedApp ⇒ app.position.isDefined must_== hasRanking
+    }
+
+    def hasRankingInfoForAll(hasRanking: Boolean): Matcher[RankedAppsByCategory] = {
+      ranking: RankedAppsByCategory ⇒ ranking.packages must contain(hasRankingInfo(hasRanking)).forall
     }
   }
 }
@@ -77,7 +81,7 @@ class RankingsProcessesSpec extends RankingsProcessesSpecification {
     "return an empty response if no device apps are given" in new BasicScope {
       val response = rankingProcesses.getRankedDeviceApps(location, emptyUnrankedAppsMap)
 
-      response.foldMap(testInterpreters) must beRight[Map[String, List[RankedApp]]](emptyRankedAppsMap)
+      response.foldMap(testInterpreters) must beRight[List[RankedAppsByCategory]](Nil)
     }
     "return all the device apps as ranked if there is ranking info for them" in new BasicScope {
       countryServices.getCountryByIsoCode2("US") returns NineCardsService.right(country)
@@ -85,8 +89,8 @@ class RankingsProcessesSpec extends RankingsProcessesSpecification {
 
       val response = rankingProcesses.getRankedDeviceApps(location, unrankedAppsMap)
 
-      response.foldMap(testInterpreters) must beRight[Map[String, List[RankedApp]]].which { r ⇒
-        r.values.flatten must contain(hasRankingInfo(true)).forall
+      response.foldMap(testInterpreters) must beRight[List[RankedAppsByCategory]].which { r ⇒
+        r must contain(hasRankingInfoForAll(true)).forall
       }
     }
     "return all the device apps as ranked by using world ranking if an unknown country is given" in new BasicScope {
@@ -95,8 +99,8 @@ class RankingsProcessesSpec extends RankingsProcessesSpecification {
 
       val response = rankingProcesses.getRankedDeviceApps(location, unrankedAppsMap)
 
-      response.foldMap(testInterpreters) must beRight[Map[String, List[RankedApp]]].which { r ⇒
-        r.values.flatten must contain(hasRankingInfo(true)).forall
+      response.foldMap(testInterpreters) must beRight[List[RankedAppsByCategory]].which { r ⇒
+        r must contain(hasRankingInfoForAll(true)).forall
       }
     }
     "return all the device apps as unranked if there is no ranking info for them" in new BasicScope {
@@ -105,8 +109,8 @@ class RankingsProcessesSpec extends RankingsProcessesSpecification {
 
       val response = rankingProcesses.getRankedDeviceApps(location, unrankedAppsMap)
 
-      response.foldMap(testInterpreters) must beRight[Map[String, List[RankedApp]]].which { r ⇒
-        r.values.flatten must contain(hasRankingInfo(false)).forall
+      response.foldMap(testInterpreters) must beRight[List[RankedAppsByCategory]].which { r ⇒
+        r must contain(hasRankingInfoForAll(false)).forall
       }
     }
 
@@ -116,7 +120,7 @@ class RankingsProcessesSpec extends RankingsProcessesSpecification {
     "return an empty response if no device apps are given" in new BasicScope {
       val response = rankingProcesses.getRankedAppsByMoment(location, emptyUnrankedAppsList, moments)
 
-      response.foldMap(testInterpreters) must beRight[Map[String, List[RankedApp]]](emptyRankedAppsMap)
+      response.foldMap(testInterpreters) must beRight[List[RankedAppsByCategory]](Nil)
     }
     "return all the apps as ranked if there is ranking info for them" in new BasicScope {
       countryServices.getCountryByIsoCode2("US") returns NineCardsService.right(country)
@@ -125,8 +129,8 @@ class RankingsProcessesSpec extends RankingsProcessesSpecification {
 
       val response = rankingProcesses.getRankedAppsByMoment(location, unrankedAppsList, moments)
 
-      response.foldMap(testInterpreters) must beRight[Map[String, List[RankedApp]]].which { r ⇒
-        r.values.flatten must contain(hasRankingInfo(true)).forall
+      response.foldMap(testInterpreters) must beRight[List[RankedAppsByCategory]].which { r ⇒
+        r must contain(hasRankingInfoForAll(true)).forall
       }
     }
     "return all the  apps as ranked by using world ranking if an unknown country is given" in new BasicScope {
@@ -136,18 +140,18 @@ class RankingsProcessesSpec extends RankingsProcessesSpecification {
 
       val response = rankingProcesses.getRankedAppsByMoment(location, unrankedAppsList, moments)
 
-      response.foldMap(testInterpreters) must beRight[Map[String, List[RankedApp]]].which { r ⇒
-        r.values.flatten must contain(hasRankingInfo(true)).forall
+      response.foldMap(testInterpreters) must beRight[List[RankedAppsByCategory]].which { r ⇒
+        r must contain(hasRankingInfoForAll(true)).forall
       }
     }
-    "return all the device apps as unranked if there is no ranking info for them" in new BasicScope {
+    "return an empty response if there is no ranking info for them" in new BasicScope {
       countryServices.getCountryByIsoCode2("US") returns NineCardsService.right(country)
       rankingServices.getRankingForAppsWithinMoments(mockEq(usaScope), any, mockEq(moments)) returns
         rankingForAppsEmptyResponse
 
       val response = rankingProcesses.getRankedAppsByMoment(location, unrankedAppsList, moments)
 
-      response.foldMap(testInterpreters) must beRight[Map[String, List[RankedApp]]](emptyRankedAppsMap)
+      response.foldMap(testInterpreters) must beRight[List[RankedAppsByCategory]](Nil)
     }
 
   }


### PR DESCRIPTION
This pull request change the structure of the response for the `rank` endpoints by using `List` instead of `Map`. The reason is that we want to maintain the order of the results included into the response.

@javipacheco Could you take a look please? Thanks!
