### PR TITLE
9C-1019: Converts all ISO code passed as parameter to lowercase

### DIFF
--- a/modules/processes/src/main/scala/cards/nine/processes/RankingProcesses.scala
+++ b/modules/processes/src/main/scala/cards/nine/processes/RankingProcesses.scala
@@ -29,7 +29,7 @@ class RankingProcesses[F[_]](
     def getCountryName(scope: GeoScope): NineCardsService[F, Option[CountryName]] = scope match {
       case WorldScope ⇒ NineCardsService.right[F, Option[CountryName]](None)
       case CountryScope(code) ⇒
-        countryPersistence.getCountryByIsoCode2(code.value.toUpperCase).map(c ⇒ Option(CountryName(c.name)))
+        countryPersistence.getCountryByIsoCode2(code.value).map(c ⇒ Option(CountryName(c.name)))
     }
 
     for {

--- a/modules/services/src/main/scala/cards/nine/services/free/domain/Ranking.scala
+++ b/modules/services/src/main/scala/cards/nine/services/free/domain/Ranking.scala
@@ -25,7 +25,10 @@ object Ranking {
 
     def worldScope: CacheKey = CacheKey(WorldScope, AppsRankingByCategory)
 
-    def countryScope(code: String): CacheKey = CacheKey(CountryScope(CountryIsoCode(code)), AppsRankingByCategory)
+    def countryScope(code: String): CacheKey = CacheKey(
+      scope      = CountryScope(CountryIsoCode(code.toLowerCase)),
+      reportType = AppsRankingByCategory
+    )
 
   }
 }

--- a/modules/services/src/main/scala/cards/nine/services/free/interpreter/country/Services.scala
+++ b/modules/services/src/main/scala/cards/nine/services/free/interpreter/country/Services.scala
@@ -13,7 +13,7 @@ import doobie.imports._
 class Services(persistence: Persistence[Country]) extends (Ops ~> ConnectionIO) {
 
   def getCountryByIsoCode2(isoCode: String): ConnectionIO[Result[Country]] =
-    persistence.fetchOption(Queries.getByIsoCode2Sql, isoCode) map {
+    persistence.fetchOption(Queries.getByIsoCode2Sql, isoCode.toUpperCase) map {
       Either.fromOption(_, CountryNotFound(s"Country with ISO code2 $isoCode doesn't exist"))
     }
 


### PR DESCRIPTION
This pull request converts the country ISO codes that are passed as parameter in ranking endpoints to lowercase.

It closes 47deg/nine-cards-v2#1019

@javipacheco Could you take a look please? Thanks!
