### PR TITLE
Quick Fix: Fatal Warnings

### DIFF
--- a/modules/api/src/main/scala/cards/nine/api/utils/TaskDirectives.scala
+++ b/modules/api/src/main/scala/cards/nine/api/utils/TaskDirectives.scala
@@ -58,6 +58,7 @@ trait OnSuccessTaskMagnet {
 }
 
 object OnSuccessTaskMagnet {
+  import scala.language.existentials
   implicit def apply[T](task: ⇒ Task[T])(implicit hl: HListable[T]) =
     new Directive[hl.Out] with OnSuccessTaskMagnet {
       type Out = hl.Out

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -15,7 +15,7 @@ trait Settings {
     organizationHomepage := Some(new URL("http://47deg.com")),
     version := Versions.buildVersion,
     conflictWarning := ConflictWarning.disable,
-    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:higherKinds", "-language:implicitConversions", "-Ywarn-unused-import"),
+    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:higherKinds", "-language:implicitConversions", "-Ywarn-unused-import", "-Xfatal-warnings"),
     javaOptions in Test ++= Seq("-XX:MaxPermSize=128m", "-Xms512m", "-Xmx512m"),
     sbt.Keys.fork in Test := false,
     publishMavenStyle := true,


### PR DESCRIPTION
Add the "-XFatal-Warnings" Scalac Option, for avoiding common warnings
for unused packages and the like.

@franciscodr ¿Could you review?