### PR TITLE
9C-1141-1 Collections Processes

### DIFF
--- a/modules/api/src/main/scala/cards/nine/api/JsonFormats.scala
+++ b/modules/api/src/main/scala/cards/nine/api/JsonFormats.scala
@@ -7,7 +7,7 @@ import cards.nine.api.messages.SharedCollectionMessages._
 import cards.nine.api.messages.UserMessages._
 import cards.nine.domain.application.{ Package, Widget }
 import cards.nine.domain.account._
-import cards.nine.processes.messages.SharedCollectionMessages._
+import cards.nine.processes.collections.messages._
 import io.circe.{ Decoder, Encoder, Json }
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat

--- a/modules/api/src/main/scala/cards/nine/api/NineCardsApi.scala
+++ b/modules/api/src/main/scala/cards/nine/api/NineCardsApi.scala
@@ -17,6 +17,7 @@ import cards.nine.domain.analytics._
 import cards.nine.domain.application.{ BasicCard, Category, FullCard, Package, PriceFilter }
 import cards.nine.domain.pagination.Page
 import cards.nine.processes._
+import cards.nine.processes.collections.SharedCollectionProcesses
 import cards.nine.processes.NineCardsServices._
 
 import scala.concurrent.ExecutionContext

--- a/modules/api/src/main/scala/cards/nine/api/converters/Converters.scala
+++ b/modules/api/src/main/scala/cards/nine/api/converters/Converters.scala
@@ -10,8 +10,8 @@ import cards.nine.domain.account._
 import cards.nine.domain.analytics.{ RankedAppsByCategory, RankedWidgetsByMoment }
 import cards.nine.domain.application._
 import cards.nine.domain.market.MarketCredentials
+import cards.nine.processes.collections.messages._
 import cards.nine.processes.messages.InstallationsMessages._
-import cards.nine.processes.messages.SharedCollectionMessages._
 import cards.nine.processes.messages.UserMessages._
 import cards.nine.processes.messages.rankings.GetRankedDeviceApps._
 import cats.syntax.either._

--- a/modules/api/src/main/scala/cards/nine/api/messages/SharedCollectionMessages.scala
+++ b/modules/api/src/main/scala/cards/nine/api/messages/SharedCollectionMessages.scala
@@ -2,7 +2,7 @@ package cards.nine.api.messages
 
 import cats.data.Xor
 import cards.nine.domain.application.Package
-import cards.nine.processes.messages.SharedCollectionMessages._
+import cards.nine.processes.collections.messages._
 import org.joda.time.DateTime
 
 object SharedCollectionMessages {

--- a/modules/api/src/test/scala/cards/nine/api/NineCardsApiSpec.scala
+++ b/modules/api/src/test/scala/cards/nine/api/NineCardsApiSpec.scala
@@ -11,6 +11,7 @@ import cards.nine.commons.config.NineCardsConfig
 import cards.nine.domain.account._
 import cards.nine.processes.NineCardsServices._
 import cards.nine.processes._
+import cards.nine.processes.collections.SharedCollectionProcesses
 import cards.nine.processes.messages.UserMessages._
 import cats.free.Free
 import cats.syntax.either._

--- a/modules/api/src/test/scala/cards/nine/api/TestData.scala
+++ b/modules/api/src/test/scala/cards/nine/api/TestData.scala
@@ -10,8 +10,8 @@ import cards.nine.commons.NineCardsErrors.SharedCollectionNotFound
 import cards.nine.domain.account._
 import cards.nine.domain.analytics.{ RankedAppsByCategory, RankedWidgetsByMoment }
 import cards.nine.domain.application.{ CardList, Category, FullCard, Package }
+import cards.nine.processes.collections.messages._
 import cards.nine.processes.messages.InstallationsMessages._
-import cards.nine.processes.messages.SharedCollectionMessages._
 import cards.nine.processes.messages.UserMessages.{ LoginRequest, LoginResponse }
 import cards.nine.processes.messages.rankings.{ Get, Reload }
 import cards.nine.services.free.domain.Ranking.GoogleAnalyticsRanking

--- a/modules/api/src/test/scala/cards/nine/api/converters/ConvertersSpec.scala
+++ b/modules/api/src/test/scala/cards/nine/api/converters/ConvertersSpec.scala
@@ -6,8 +6,8 @@ import cards.nine.api.messages.UserMessages._
 import cards.nine.domain.account.{ AndroidId, SessionToken }
 import cards.nine.domain.application.{ BasicCard, CardList, FullCard }
 import cards.nine.domain.market.{ MarketToken, Localization }
+import cards.nine.processes.collections.messages._
 import cards.nine.processes.messages.InstallationsMessages._
-import cards.nine.processes.messages.SharedCollectionMessages._
 import cards.nine.processes.messages.UserMessages._
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Shapeless._

--- a/modules/processes/src/main/scala/cards/nine/processes/collections/Converters.scala
+++ b/modules/processes/src/main/scala/cards/nine/processes/collections/Converters.scala
@@ -1,0 +1,87 @@
+package cards.nine.processes.collections
+
+import java.sql.Timestamp
+
+import cards.nine.domain.application.{ CardList, FullCard, Moment, Package }
+import cards.nine.processes.collections.messages._
+import cards.nine.services.free.domain.{ BaseSharedCollection, SharedCollectionWithAggregatedInfo, SharedCollection ⇒ SharedCollectionServices, SharedCollectionSubscription ⇒ SharedCollectionSubscriptionServices }
+import cards.nine.services.free.interpreter.collection.Services.{ SharedCollectionData ⇒ SharedCollectionDataServices }
+import org.joda.time.DateTime
+
+object Converters {
+
+  implicit def toJodaDateTime(timestamp: Timestamp): DateTime = new DateTime(timestamp.getTime)
+
+  implicit def toTimestamp(datetime: DateTime): Timestamp = new Timestamp(datetime.getMillis)
+
+  implicit def toSharedCollectionDataServices(
+    data: SharedCollectionData
+  ): SharedCollectionDataServices =
+    SharedCollectionDataServices(
+      publicIdentifier = data.publicIdentifier,
+      userId           = data.userId,
+      publishedOn      = data.publishedOn,
+      author           = data.author,
+      name             = data.name,
+      views            = data.views.getOrElse(0),
+      category         = data.category,
+      icon             = data.icon,
+      community        = data.community,
+      packages         = data.packages map (_.value)
+    )
+
+  def toSharedCollectionList(userId: Long)(collections: List[BaseSharedCollection]): List[SharedCollection] =
+    collections map (col ⇒ toSharedCollection(col, userId))
+
+  def toSharedCollection(collection: BaseSharedCollection, userId: Long): SharedCollection =
+    collection match {
+      case (c: SharedCollectionWithAggregatedInfo) ⇒
+        toSharedCollection(c.sharedCollectionData, Option(c.subscriptionsCount), userId)
+      case (c: SharedCollectionServices) ⇒
+        toSharedCollection(c, None, userId)
+    }
+
+  def toSharedCollection(
+    collection: SharedCollectionServices,
+    subscriptionCount: Option[Long],
+    userId: Long
+  ) =
+    SharedCollection(
+      publicIdentifier   = collection.publicIdentifier,
+      publishedOn        = collection.publishedOn,
+      author             = collection.author,
+      name               = collection.name,
+      views              = collection.views,
+      category           = collection.category,
+      icon               = collection.icon,
+      community          = collection.community,
+      owned              = collection.userId.fold(false)(user ⇒ user == userId),
+      packages           = collection.packages map Package,
+      subscriptionsCount = subscriptionCount
+    )
+
+  def toSharedCollectionWithAppsInfo[A](
+    collection: SharedCollection,
+    appsInfo: List[A]
+  ): SharedCollectionWithAppsInfo[A] =
+    SharedCollectionWithAppsInfo(
+      collection = collection,
+      appsInfo   = appsInfo
+    )
+
+  def filterCategorized(info: CardList[FullCard]): CardList[FullCard] = {
+    val (appsWithoutCategories, apps) = info.cards.partition(app ⇒ app.categories.isEmpty)
+    CardList(
+      missing = info.missing ++ appsWithoutCategories.map(_.packageName),
+      cards   = apps
+    )
+  }
+
+  def toGetSubscriptionsByUserResponse(subscriptions: List[SharedCollectionSubscriptionServices]) =
+    GetSubscriptionsByUserResponse(
+      subscriptions map (_.sharedCollectionPublicId)
+    )
+
+  def toMoment(widgetMoment: String) = widgetMoment.replace(Moment.widgetMomentPrefix, "")
+
+}

--- a/modules/processes/src/main/scala/cards/nine/processes/collections/Messages.scala
+++ b/modules/processes/src/main/scala/cards/nine/processes/collections/Messages.scala
@@ -1,9 +1,9 @@
-package cards.nine.processes.messages
+package cards.nine.processes.collections
 
 import cards.nine.domain.application.{ BasicCard, FullCard, Package }
 import org.joda.time.DateTime
 
-object SharedCollectionMessages {
+package messages {
 
   case class SharedCollectionData(
     publicIdentifier: String,

--- a/modules/processes/src/main/scala/cards/nine/processes/collections/SharedCollectionProcesses.scala
+++ b/modules/processes/src/main/scala/cards/nine/processes/collections/SharedCollectionProcesses.scala
@@ -1,12 +1,11 @@
-package cards.nine.processes
+package cards.nine.processes.collections
 
 import cards.nine.commons.NineCardsService
 import cards.nine.commons.NineCardsService.NineCardsService
 import cards.nine.domain.application.{ BasicCard, CardList, Package }
 import cards.nine.domain.market.MarketCredentials
 import cards.nine.domain.pagination.Page
-import cards.nine.processes.converters.Converters._
-import cards.nine.processes.messages.SharedCollectionMessages._
+import cards.nine.processes.collections.messages._
 import cards.nine.services.free.algebra
 import cards.nine.services.free.algebra.{ Firebase, GooglePlay }
 import cards.nine.services.free.domain.Firebase._
@@ -20,6 +19,8 @@ class SharedCollectionProcesses[F[_]](
   subscriptionServices: algebra.Subscription.Services[F],
   userServices: algebra.User.Services[F]
 ) {
+
+  import Converters._
 
   def createCollection(request: CreateCollectionRequest): NineCardsService[F, CreateOrUpdateCollectionResponse] =
     collectionServices.add(request.collection) map { collection ⇒

--- a/modules/processes/src/main/scala/cards/nine/processes/converters/Converters.scala
+++ b/modules/processes/src/main/scala/cards/nine/processes/converters/Converters.scala
@@ -5,10 +5,8 @@ import java.sql.Timestamp
 import cards.nine.domain.analytics._
 import cards.nine.domain.application.{ CardList, FullCard, Moment, Package }
 import cards.nine.processes.messages.InstallationsMessages._
-import cards.nine.processes.messages.SharedCollectionMessages._
 import cards.nine.processes.messages.UserMessages.LoginResponse
-import cards.nine.services.free.domain.{ BaseSharedCollection, SharedCollectionWithAggregatedInfo, Installation ⇒ InstallationServices, SharedCollection ⇒ SharedCollectionServices, SharedCollectionSubscription ⇒ SharedCollectionSubscriptionServices, User ⇒ UserAppServices }
-import cards.nine.services.free.interpreter.collection.Services.{ SharedCollectionData ⇒ SharedCollectionDataServices }
+import cards.nine.services.free.domain.{ Installation ⇒ InstallationServices, User ⇒ UserAppServices }
 import org.joda.time.DateTime
 
 object Converters {
@@ -31,61 +29,6 @@ object Converters {
       deviceToken = installation.deviceToken
     )
 
-  implicit def toSharedCollectionDataServices(
-    data: SharedCollectionData
-  ): SharedCollectionDataServices =
-    SharedCollectionDataServices(
-      publicIdentifier = data.publicIdentifier,
-      userId           = data.userId,
-      publishedOn      = data.publishedOn,
-      author           = data.author,
-      name             = data.name,
-      views            = data.views.getOrElse(0),
-      category         = data.category,
-      icon             = data.icon,
-      community        = data.community,
-      packages         = data.packages map (_.value)
-    )
-
-  def toSharedCollectionList(userId: Long)(collections: List[BaseSharedCollection]): List[SharedCollection] =
-    collections map (col ⇒ toSharedCollection(col, userId))
-
-  def toSharedCollection(collection: BaseSharedCollection, userId: Long): SharedCollection =
-    collection match {
-      case (c: SharedCollectionWithAggregatedInfo) ⇒
-        toSharedCollection(c.sharedCollectionData, Option(c.subscriptionsCount), userId)
-      case (c: SharedCollectionServices) ⇒
-        toSharedCollection(c, None, userId)
-    }
-
-  def toSharedCollection(
-    collection: SharedCollectionServices,
-    subscriptionCount: Option[Long],
-    userId: Long
-  ) =
-    SharedCollection(
-      publicIdentifier   = collection.publicIdentifier,
-      publishedOn        = collection.publishedOn,
-      author             = collection.author,
-      name               = collection.name,
-      views              = collection.views,
-      category           = collection.category,
-      icon               = collection.icon,
-      community          = collection.community,
-      owned              = collection.userId.fold(false)(user ⇒ user == userId),
-      packages           = collection.packages map Package,
-      subscriptionsCount = subscriptionCount
-    )
-
-  def toSharedCollectionWithAppsInfo[A](
-    collection: SharedCollection,
-    appsInfo: List[A]
-  ): SharedCollectionWithAppsInfo[A] =
-    SharedCollectionWithAppsInfo(
-      collection = collection,
-      appsInfo   = appsInfo
-    )
-
   def filterCategorized(info: CardList[FullCard]): CardList[FullCard] = {
     val (appsWithoutCategories, apps) = info.cards.partition(app ⇒ app.categories.isEmpty)
     CardList(
@@ -93,11 +36,6 @@ object Converters {
       cards   = apps
     )
   }
-
-  def toGetSubscriptionsByUserResponse(subscriptions: List[SharedCollectionSubscriptionServices]) =
-    GetSubscriptionsByUserResponse(
-      subscriptions map (_.sharedCollectionPublicId)
-    )
 
   def toUnrankedApp(category: String)(pack: Package) = UnrankedApp(pack, category)
 

--- a/modules/processes/src/test/scala/cards/nine/processes/TestData.scala
+++ b/modules/processes/src/test/scala/cards/nine/processes/TestData.scala
@@ -2,8 +2,7 @@ package cards.nine.processes
 
 import java.sql.Timestamp
 import java.time.Instant
-
-import cards.nine.commons.NineCardsErrors.{ CountryNotFound, RankingNotFound, SharedCollectionNotFound }
+import cards.nine.commons.NineCardsErrors.{ CountryNotFound, RankingNotFound }
 import cards.nine.commons.NineCardsService
 import cards.nine.domain.account.{ AndroidId, DeviceToken }
 import cards.nine.domain.analytics._
@@ -12,11 +11,8 @@ import cards.nine.domain.market.{ Localization, MarketCredentials, MarketToken }
 import cards.nine.domain.pagination.Page
 import cards.nine.processes.NineCardsServices.NineCardsServices
 import cards.nine.processes.converters.Converters
-import cards.nine.processes.messages.SharedCollectionMessages._
-import cards.nine.services.free.domain.Firebase.{ NotificationIndividualResult, SendNotificationResponse }
 import cards.nine.services.free.domain.Ranking.GoogleAnalyticsRanking
-import cards.nine.services.free.domain.{ SharedCollection ⇒ SharedCollectionServices, _ }
-import cards.nine.services.free.interpreter.collection.Services.{ SharedCollectionData ⇒ SharedCollectionDataServices }
+import cards.nine.services.free.domain.{ Country, Installation }
 import org.joda.time.{ DateTime, DateTimeZone }
 
 object TestData {
@@ -32,8 +28,6 @@ object TestData {
   val canonicalId = 0
 
   val category = "SOCIAL"
-
-  val collectionId = 1l
 
   val community = true
 
@@ -88,8 +82,6 @@ object TestData {
   val success = 1
 
   val token = "6d54dfed-bbcf-47a5-b8f2-d86cf3320631"
-
-  val updatedCollectionsCount = 1
 
   val userId = Option(publisherId)
 
@@ -150,25 +142,6 @@ object TestData {
       token        = MarketToken(token)
     )
 
-    val collection = SharedCollectionServices(
-      id               = collectionId,
-      publicIdentifier = publicIdentifier,
-      userId           = userId,
-      publishedOn      = publishedOnTimestamp,
-      author           = author,
-      name             = name,
-      views            = views,
-      category         = category,
-      icon             = icon,
-      community        = community,
-      packages         = packagesName map (_.value)
-    )
-
-    val collectionWithSubscriptions = SharedCollectionWithAggregatedInfo(
-      sharedCollectionData = collection,
-      subscriptionsCount   = subscriptionsCount
-    )
-
     val country = Country(
       isoCode2  = countryIsoCode2,
       isoCode3  = Option(countryIsoCode3),
@@ -177,12 +150,6 @@ object TestData {
     )
 
     val countryNotFoundError = CountryNotFound(s"Country with ISO code2 US doesn't exist")
-
-    val sharedCollectionNotFoundError = SharedCollectionNotFound("Shared collection not found")
-
-    val createPackagesStats = PackagesStats(packagesName.size, None)
-
-    val updatePackagesStats = PackagesStats(addedPackagesCount, Option(removedPackagesCount))
 
     val appInfoList = packagesName map { packageName ⇒
       FullCard(packageName, "Germany", List(appCategory), "100.000+", true, icon, Nil, stars)
@@ -193,116 +160,6 @@ object TestData {
       userId      = subscriberId,
       deviceToken = Option(deviceToken),
       androidId   = androidId
-    )
-
-    val sendNotificationResponse = SendNotificationResponse(
-      multicastIds = List(multicastId),
-      success      = success,
-      failure      = failure,
-      canonicalIds = canonicalId,
-      results      = List(NotificationIndividualResult(
-        message_id      = Option(messageId),
-        registration_id = None,
-        error           = None
-      ))
-    )
-
-    val sharedCollectionDataServices = SharedCollectionDataServices(
-      publicIdentifier = publicIdentifier,
-      userId           = userId,
-      publishedOn      = publishedOnTimestamp,
-      author           = author,
-      name             = name,
-      views            = views,
-      category         = category,
-      icon             = icon,
-      community        = community,
-      packages         = packagesName map (_.value)
-    )
-
-    val sharedCollectionData = SharedCollectionData(
-      publicIdentifier = publicIdentifier,
-      userId           = userId,
-      publishedOn      = publishedOnDatetime,
-      author           = author,
-      name             = name,
-      views            = Option(views),
-      category         = category,
-      icon             = icon,
-      community        = community,
-      packages         = packagesName
-    )
-
-    val sharedCollection = SharedCollection(
-      publicIdentifier = publicIdentifier,
-      publishedOn      = new DateTime(publishedOnTimestamp.getTime),
-      author           = author,
-      name             = name,
-      views            = views,
-      category         = category,
-      icon             = icon,
-      community        = community,
-      owned            = true,
-      packages         = packagesName
-    )
-
-    val sharedCollectionWithSubscriptions = SharedCollection(
-      publicIdentifier   = publicIdentifier,
-      publishedOn        = new DateTime(publishedOnTimestamp.getTime),
-      author             = author,
-      name               = name,
-      views              = views,
-      category           = category,
-      icon               = icon,
-      community          = community,
-      owned              = true,
-      packages           = packagesName,
-      subscriptionsCount = Option(subscriptionsCount)
-    )
-
-    val sharedCollectionUpdateInfo = SharedCollectionUpdateInfo(
-      title = name
-    )
-
-    val sharedCollectionWithAppsInfo = SharedCollectionWithAppsInfo(
-      collection = sharedCollection,
-      appsInfo   = appInfoList
-    )
-
-    val sharedCollectionWithAppsInfoBasic = SharedCollectionWithAppsInfo(
-      collection = sharedCollection,
-      appsInfo   = appInfoList map (_.toBasic)
-    )
-
-    val sharedCollectionWithAppsInfoAndSubscriptions = SharedCollectionWithAppsInfo(
-      collection = sharedCollectionWithSubscriptions,
-      appsInfo   = appInfoList map (_.toBasic)
-    )
-
-    val subscription = SharedCollectionSubscription(
-      sharedCollectionId       = collectionId,
-      userId                   = subscriberId,
-      sharedCollectionPublicId = publicIdentifier
-    )
-
-    val updatedSubscriptionsCount = 1
-  }
-
-  object Messages {
-
-    import Values._
-
-    val createCollectionRequest: CreateCollectionRequest = CreateCollectionRequest(
-      collection = sharedCollectionData
-    )
-
-    val createCollectionResponse = CreateOrUpdateCollectionResponse(
-      publicIdentifier = publicIdentifier,
-      packagesStats    = createPackagesStats
-    )
-
-    val getCollectionByPublicIdentifierResponse = GetCollectionByPublicIdentifierResponse(
-      data = sharedCollectionWithAppsInfo
     )
 
   }

--- a/modules/processes/src/test/scala/cards/nine/processes/collections/ConvertersSpec.scala
+++ b/modules/processes/src/test/scala/cards/nine/processes/collections/ConvertersSpec.scala
@@ -1,0 +1,24 @@
+package cards.nine.processes.collections
+
+import cards.nine.services.free.domain._
+import org.scalacheck.Shapeless._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+class ConvertersSpec
+  extends Specification
+  with ScalaCheck {
+
+  "toGetSubscriptionsByUserResponse" should {
+    "convert a list of SharedCollectionSubscription to a GetSubscriptionsByUserResponse object" in {
+      prop { subscriptions: List[SharedCollectionSubscription] ⇒
+
+        val response = Converters.toGetSubscriptionsByUserResponse(subscriptions)
+
+        forall(response.subscriptions) { publicId ⇒
+          subscriptions.exists(_.sharedCollectionPublicId == publicId)
+        }
+      }
+    }
+  }
+}

--- a/modules/processes/src/test/scala/cards/nine/processes/collections/ProcessesSpec.scala
+++ b/modules/processes/src/test/scala/cards/nine/processes/collections/ProcessesSpec.scala
@@ -1,12 +1,13 @@
-package cards.nine.processes
+package cards.nine.processes.collections
 
 import cards.nine.commons.NineCardsService
 import cards.nine.commons.NineCardsService._
 import cards.nine.processes.NineCardsServices._
-import cards.nine.processes.TestData.Messages._
-import cards.nine.processes.TestData.Values._
-import cards.nine.processes.TestData._
-import cards.nine.processes.messages.SharedCollectionMessages._
+import cards.nine.processes.TestInterpreters
+import cards.nine.processes.collections.TestData.Messages._
+import cards.nine.processes.collections.TestData.Values._
+import cards.nine.processes.collections.TestData._
+import cards.nine.processes.collections.messages._
 import cards.nine.services.free.algebra
 import cards.nine.services.free.algebra._
 import org.specs2.ScalaCheck

--- a/modules/processes/src/test/scala/cards/nine/processes/collections/TestData.scala
+++ b/modules/processes/src/test/scala/cards/nine/processes/collections/TestData.scala
@@ -1,0 +1,296 @@
+package cards.nine.processes.collections
+
+import java.sql.Timestamp
+import java.time.Instant
+
+import cards.nine.commons.NineCardsErrors.SharedCollectionNotFound
+import cards.nine.domain.account.{ AndroidId, DeviceToken }
+import cards.nine.domain.application.{ CardList, FullCard, Package }
+import cards.nine.domain.market.{ Localization, MarketCredentials, MarketToken }
+import cards.nine.domain.pagination.Page
+import cards.nine.processes.collections.messages._
+import cards.nine.services.free.domain.{ SharedCollection ⇒ SharedCollectionServices, _ }
+import cards.nine.services.free.domain.Firebase.{ NotificationIndividualResult, SendNotificationResponse }
+import cards.nine.services.free.interpreter.collection.Services.{ SharedCollectionData ⇒ SharedCollectionDataServices }
+import org.joda.time.DateTime
+
+object TestData {
+
+  val addedPackagesCount = 2
+
+  val androidId = AndroidId("50a4dbf7-85a2-4875-8c75-7232c237808c")
+
+  val appCategory = "COUNTRY"
+
+  val author = "John Doe"
+
+  val canonicalId = 0
+
+  val category = "SOCIAL"
+
+  val collectionId = 1l
+
+  val community = true
+
+  val countryContinent = "Americas"
+
+  val countryIsoCode2 = "US"
+
+  val countryIsoCode3 = "USA"
+
+  val countryName = "United States"
+
+  val deviceToken = DeviceToken("5d56922c-5257-4392-817e-503166cd7afd")
+
+  val failure = 0
+
+  val icon = "path-to-icon"
+
+  val installationId = 10l
+
+  val localization = Localization("en-EN")
+
+  val messageId = "a000dcbd-5419-446f-b2c6-6eaefd88480c"
+
+  val millis = 1453226400000l
+
+  val multicastId = 15L
+
+  val name = "The best social media apps"
+
+  val pageNumber = 0
+
+  val pageSize = 25
+
+  val pageParams = Page(pageNumber, pageSize)
+
+  val publicIdentifier = "40daf308-fecf-4228-9262-a712d783cf49"
+
+  val publishedOnDatetime = new DateTime(millis)
+
+  val publishedOnTimestamp = Timestamp.from(Instant.ofEpochMilli(millis))
+
+  val publisherId = 27L
+
+  val removedPackagesCount = 1
+
+  val stars = 5.0d
+
+  val subscriberId = 42L
+
+  val subscriptionsCount = 5L
+
+  val success = 1
+
+  val token = "6d54dfed-bbcf-47a5-b8f2-d86cf3320631"
+
+  val updatedCollectionsCount = 1
+
+  val userId = Option(publisherId)
+
+  val views = 1
+
+  val packagesName = List(
+    "earth.europe.italy",
+    "earth.europe.unitedKingdom",
+    "earth.europe.germany",
+    "earth.europe.france",
+    "earth.europe.portugal",
+    "earth.europe.spain"
+  ) map Package
+
+  val missing = List(
+    "earth.europe.italy",
+    "earth.europe.unitedKingdom"
+  ) map Package
+
+  val updatePackagesName = List(
+    "earth.europe.italy",
+    "earth.europe.unitedKingdom",
+    "earth.europe.germany"
+  ) map Package
+
+  val addedPackages = List(
+    "earth.europe.italy",
+    "earth.europe.unitedKingdom"
+  ) map Package
+
+  val removedPackages = List(
+    "earth.europe.germany"
+  ) map Package
+
+  val updatedPackages = (addedPackages, removedPackages)
+
+  object Values {
+
+    val apps = packagesName map { packageName ⇒
+      FullCard(
+        packageName = packageName,
+        title       = "Germany",
+        free        = true,
+        icon        = icon,
+        stars       = stars,
+        downloads   = "100.000+",
+        categories  = List(appCategory),
+        screenshots = Nil
+      )
+    }
+
+    val appsInfo = CardList(missing, apps)
+    val appsInfoBasic = CardList(missing, apps.map(_.toBasic))
+
+    val marketAuth = MarketCredentials(
+      androidId    = androidId,
+      localization = Some(localization),
+      token        = MarketToken(token)
+    )
+
+    val collection = SharedCollectionServices(
+      id               = collectionId,
+      publicIdentifier = publicIdentifier,
+      userId           = userId,
+      publishedOn      = publishedOnTimestamp,
+      author           = author,
+      name             = name,
+      views            = views,
+      category         = category,
+      icon             = icon,
+      community        = community,
+      packages         = packagesName map (_.value)
+    )
+
+    val collectionWithSubscriptions = SharedCollectionWithAggregatedInfo(
+      sharedCollectionData = collection,
+      subscriptionsCount   = subscriptionsCount
+    )
+
+    val sharedCollectionNotFoundError = SharedCollectionNotFound("Shared collection not found")
+
+    val createPackagesStats = PackagesStats(packagesName.size, None)
+
+    val updatePackagesStats = PackagesStats(addedPackagesCount, Option(removedPackagesCount))
+
+    val appInfoList = packagesName map { packageName ⇒
+      FullCard(packageName, "Germany", List(appCategory), "100.000+", true, icon, Nil, stars)
+    }
+
+    val installation = Installation(
+      id          = installationId,
+      userId      = subscriberId,
+      deviceToken = Option(deviceToken),
+      androidId   = androidId
+    )
+
+    val sendNotificationResponse = SendNotificationResponse(
+      multicastIds = List(multicastId),
+      success      = success,
+      failure      = failure,
+      canonicalIds = canonicalId,
+      results      = List(NotificationIndividualResult(
+        message_id      = Option(messageId),
+        registration_id = None,
+        error           = None
+      ))
+    )
+
+    val sharedCollectionDataServices = SharedCollectionDataServices(
+      publicIdentifier = publicIdentifier,
+      userId           = userId,
+      publishedOn      = publishedOnTimestamp,
+      author           = author,
+      name             = name,
+      views            = views,
+      category         = category,
+      icon             = icon,
+      community        = community,
+      packages         = packagesName map (_.value)
+    )
+
+    val sharedCollectionData = SharedCollectionData(
+      publicIdentifier = publicIdentifier,
+      userId           = userId,
+      publishedOn      = publishedOnDatetime,
+      author           = author,
+      name             = name,
+      views            = Option(views),
+      category         = category,
+      icon             = icon,
+      community        = community,
+      packages         = packagesName
+    )
+
+    val sharedCollection = SharedCollection(
+      publicIdentifier = publicIdentifier,
+      publishedOn      = new DateTime(publishedOnTimestamp.getTime),
+      author           = author,
+      name             = name,
+      views            = views,
+      category         = category,
+      icon             = icon,
+      community        = community,
+      owned            = true,
+      packages         = packagesName
+    )
+
+    val sharedCollectionWithSubscriptions = SharedCollection(
+      publicIdentifier   = publicIdentifier,
+      publishedOn        = new DateTime(publishedOnTimestamp.getTime),
+      author             = author,
+      name               = name,
+      views              = views,
+      category           = category,
+      icon               = icon,
+      community          = community,
+      owned              = true,
+      packages           = packagesName,
+      subscriptionsCount = Option(subscriptionsCount)
+    )
+
+    val sharedCollectionUpdateInfo = SharedCollectionUpdateInfo(
+      title = name
+    )
+
+    val sharedCollectionWithAppsInfo = SharedCollectionWithAppsInfo(
+      collection = sharedCollection,
+      appsInfo   = appInfoList
+    )
+
+    val sharedCollectionWithAppsInfoBasic = SharedCollectionWithAppsInfo(
+      collection = sharedCollection,
+      appsInfo   = appInfoList map (_.toBasic)
+    )
+
+    val sharedCollectionWithAppsInfoAndSubscriptions = SharedCollectionWithAppsInfo(
+      collection = sharedCollectionWithSubscriptions,
+      appsInfo   = appInfoList map (_.toBasic)
+    )
+
+    val subscription = SharedCollectionSubscription(
+      sharedCollectionId       = collectionId,
+      userId                   = subscriberId,
+      sharedCollectionPublicId = publicIdentifier
+    )
+
+    val updatedSubscriptionsCount = 1
+  }
+
+  object Messages {
+
+    import Values._
+
+    val createCollectionRequest: CreateCollectionRequest = CreateCollectionRequest(
+      collection = sharedCollectionData
+    )
+
+    val createCollectionResponse = CreateOrUpdateCollectionResponse(
+      publicIdentifier = publicIdentifier,
+      packagesStats    = createPackagesStats
+    )
+
+    val getCollectionByPublicIdentifierResponse = GetCollectionByPublicIdentifierResponse(
+      data = sharedCollectionWithAppsInfo
+    )
+
+  }
+
+}

--- a/modules/processes/src/test/scala/cards/nine/processes/converters/ConvertersSpec.scala
+++ b/modules/processes/src/test/scala/cards/nine/processes/converters/ConvertersSpec.scala
@@ -52,16 +52,4 @@ class ConvertersSpec
     }
   }
 
-  "toGetSubscriptionsByUserResponse" should {
-    "convert a list of SharedCollectionSubscription to a GetSubscriptionsByUserResponse object" in {
-      prop { subscriptions: List[SharedCollectionSubscription] ⇒
-
-        val response = Converters.toGetSubscriptionsByUserResponse(subscriptions)
-
-        forall(response.subscriptions) { publicId ⇒
-          subscriptions.exists(_.sharedCollectionPublicId == publicId)
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
This is one of the partial PRs for [ticket 1141](https://github.com/47deg/nine-cards-v2/issues/1141). 

We modify the `processes` module to extract in a separate package the processes, messages, converters, and tests related to shared collections. We also modify the necessary imports in the `api` module.

@franciscodr ¿Could you review?