### PR TITLE
9C -  Simplify Mocks from test code

### DIFF
--- a/assets/postman/collection.json
+++ b/assets/postman/collection.json
@@ -30,7 +30,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"email\": \"user@example.com\",\n    \"androidId\":\"111a-bbb2-cc3-4444f\",\n    \"tokenId\":\"Y29udGVudC5jb20iLCJzdWIiOiIxMDYyMjI2OTM3MTk4N\"\n}"
+							"raw": "{\n    \"email\": \"user@example.com\",\n    \"androidId\":\"111a-bbb2-cc3-4444f\",\n    \"tokenId\":\"{{OBTAIN_TOKEN_ID}}\"\n}"
 						},
 						"description": "Signs up a client (user and device) within the Nine Cards Backend.\n\nIts response should include the new client's session token and its api key."
 					},

--- a/endpoints.md
+++ b/endpoints.md
@@ -305,7 +305,7 @@ For example, a valid request body would be the following one:
 {
   "email"     : "jon.doe@gmail.com",
   "androidId" : "1CAFE80C",
-  "tokenId"   : "k23.k1Li4iliMa_"
+  "tokenId"   : "k10.qwertyuiop_"
 }
 ```
 

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -141,17 +141,19 @@ ninecards {
     url = ${?REDIS_URL}
   }
 
-  secretKey = "24b0d08be9f3dbad827790ec030e0d22"
+  secretKey = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
   secretKey = ${?NINECARDS_SECRET_KEY}
-  salt = "b3078558091d7bdf6c1bc425ce59f14f"
+  salt = "11111111111111111111111111111111"
   salt = ${?NINECARDS_SALT}
 
   editors {
   }
 
   test {
-    androidId = "37A5db12145ac816"
-    token = "kwMF-R2U8FXt57w-3QqgAmCm6BPKOpd0DgZqeeEn4wWEloWWC6W4obviQwYv2Dq2MqmVcQ."
+    androidId = ""
+    androidId = ${?TESTING_GOOGLE_MARKET_API_ANDROIDID}
+    token = ""
+    token = ${?TESTING_GOOGLE_MARKET_API_TOKEN}
     localization = "en-US"
     googlePlayDetailsAppUrl = "https://play.google.com/store/apps/details"
   }

--- a/modules/api/src/test/scala/cards/nine/api/TestData.scala
+++ b/modules/api/src/test/scala/cards/nine/api/TestData.scala
@@ -22,25 +22,23 @@ import spray.http.HttpHeaders.RawHeader
 
 object TestData {
 
-  val androidId = AndroidId("f07a13984f6d116a")
+  val androidId = AndroidId("aaaaaaaaaaaaaaaa")
 
-  val apiToken = ApiKey("a7db875d-f11e-4b0c-8d7a-db210fd93e1b")
+  val apiToken = ApiKey("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
 
   val author = "John Doe"
 
-  val authToken = "c8abd539-d912-4eff-8d3c-679307defc71"
+  val authToken = "dddddddd-dddd-dddd-dddd-dddddddddddd"
 
   val category = "SOCIAL"
 
-  val deviceToken = Option(DeviceToken("d897b6f1-c6a9-42bd-bf42-c787883c7d3e"))
+  val deviceToken = Option(DeviceToken("77777777-7777-7777-7777-777777777777"))
 
   val email = Email("valid.email@test.com")
 
-  val failingAuthToken = "a439c00e"
+  val failingAuthToken = "abcdefg"
 
-  val googlePlayToken = "8d8f9814"
-
-  val googleAnalyticsToken = "yada-yada-yada"
+  val googlePlayToken = "111111111"
 
   val location = Option("US")
 
@@ -50,9 +48,7 @@ object TestData {
 
   val moments = List("HOME", "NIGHT")
 
-  val sessionToken = SessionToken("1d1afeea-c7ec-45d8-a6f8-825b836f2785")
-
-  val tokenId = GoogleIdToken("6c7b303e-585e-4fe8-8b6f-586547317331-7f9b12dd-8946-4285-a72a-746e482834dd")
+  val sessionToken = SessionToken("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 
   val userId = 1l
 
@@ -75,9 +71,6 @@ object TestData {
       RawHeader(headerAuthToken, failingAuthToken)
     )
 
-    val googleAnalyticsHeaders = List(
-      RawHeader(headerGoogleAnalyticsToken, googleAnalyticsToken)
-    )
   }
 
 }

--- a/modules/api/src/test/scala/cards/nine/api/accounts/TestData.scala
+++ b/modules/api/src/test/scala/cards/nine/api/accounts/TestData.scala
@@ -24,25 +24,25 @@ import spray.http.HttpHeaders.RawHeader
 
 private[accounts] object TestData {
 
-  val androidId = AndroidId("f07a13984f6d116a")
+  val androidId = AndroidId("aaaaaaaaaaaaaaaa")
 
-  val apiToken = ApiKey("a7db875d-f11e-4b0c-8d7a-db210fd93e1b")
+  val apiToken = ApiKey("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
 
-  val authToken = "c8abd539-d912-4eff-8d3c-679307defc71"
+  val authToken = "aaaaaaaa-bbbb-bbbb-bbbb-cccccccccccc"
 
-  val deviceToken = Option(DeviceToken("d897b6f1-c6a9-42bd-bf42-c787883c7d3e"))
+  val deviceToken = Option(DeviceToken("77777777-7777-7777-7777-777777777777"))
 
   val email = Email("valid.email@test.com")
 
-  val failingAuthToken = "a439c00e"
+  val failingAuthToken = "abcdef012"
 
   val location = Option("US")
 
   val now = DateTime.now
 
-  val sessionToken = SessionToken("1d1afeea-c7ec-45d8-a6f8-825b836f2785")
+  val sessionToken = SessionToken("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 
-  val tokenId = GoogleIdToken("6c7b303e-585e-4fe8-8b6f-586547317331-7f9b12dd-8946-4285-a72a-746e482834dd")
+  val tokenId = GoogleIdToken("66666666-6666-6666-6666-666666666666")
 
   val userId = 1l
 

--- a/modules/api/src/test/scala/cards/nine/api/collections/TestData.scala
+++ b/modules/api/src/test/scala/cards/nine/api/collections/TestData.scala
@@ -60,7 +60,7 @@ private[collections] object TestData {
 
   val moments = List("HOME", "NIGHT")
 
-  val publicIdentifier = "40daf308-fecf-4228-9262-a712d783cf49"
+  val publicIdentifier = "33333333-3333-3333"
 
   val removedPackages = None
 
@@ -141,13 +141,13 @@ private[collections] object TestData {
 
     val collections = "/collections"
 
-    val collectionById = "/collections/40daf308-fecf-4228-9262-a712d783cf49"
+    val collectionById = s"/collections/${publicIdentifier}"
 
-    val increaseViews = "/collections/40daf308-fecf-4228-9262-a712d783cf49/views"
+    val increaseViews = s"/collections/${publicIdentifier}/views"
 
     val latestCollections = "/collections/latest/SOCIAL/0/25"
 
-    val subscriptionByCollectionId = "/collections/subscriptions/40daf308-fecf-4228-9262-a712d783cf49"
+    val subscriptionByCollectionId = s"/collections/subscriptions/${publicIdentifier}"
 
     val subscriptionsByUser = "/collections/subscriptions"
 

--- a/modules/commons/src/main/scala/cards/nine/commons/config/DummyConfig.scala
+++ b/modules/commons/src/main/scala/cards/nine/commons/config/DummyConfig.scala
@@ -125,8 +125,8 @@ trait DummyConfig {
   val loaderIOToken = "loaderio-localtest"
 
   object test {
-    val androidId = "65H9fv28456fj939"
-    val token = "kfh4343JGi39034LS98fi34"
+    val androidId = "androidId"
+    val token = "token"
     val localization = "en-US"
     val googlePlayDetailsAppUrl = "https://play.google.com/store/apps/details"
   }

--- a/modules/processes/src/test/scala/cards/nine/processes/account/TestData.scala
+++ b/modules/processes/src/test/scala/cards/nine/processes/account/TestData.scala
@@ -28,7 +28,7 @@ private[account] trait AccountTestData {
 
   val wrongEmail = Email("wrong.email@test.com")
 
-  val tokenId = GoogleIdToken("eyJhbGciOiJSUzI1NiIsImtpZCI6IjcxMjI3MjFlZWQwYjQ1YmUxNWUzMGI2YThhOThjOTM3ZTJlNmQxN")
+  val tokenId = GoogleIdToken("JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK")
 
   val tokenInfo = TokenInfo("true", email.value)
 
@@ -38,11 +38,11 @@ private[account] trait AccountTestData {
 
   val userId = 1l
 
-  val apiKey = "60b32e59-0d87-4705-a454-2e5b38bec13b"
+  val apiKey = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 
-  val wrongApiKey = "f93cff07-32c9-4995-8e80-a8adfafbf296"
+  val wrongApiKey = "cccccccc-cccc-cccc-cccc-cccccccccccc"
 
-  val sessionToken = "1d1afeea-c7ec-45d8-a6f8-825b836f2785"
+  val sessionToken = "dddddddd-dddd-dddd-dddd-dddddddddddd"
 
   val banned = false
 
@@ -50,9 +50,9 @@ private[account] trait AccountTestData {
 
   val userNotFoundError = UserNotFound("The user doesn't exist")
 
-  val androidId = "f07a13984f6d116a"
+  val androidId = "aaaaaaaaaaaaaaaa"
 
-  val googleTokenId = "hd-w2tmEe7SZ_8vXhw_3f1iNnsrAqkpEvbPkFIo9oZeAq26u"
+  val googleTokenId = "eg-googleTokenId"
 
   val deviceToken = "abc"
 

--- a/modules/processes/src/test/scala/cards/nine/processes/collections/TestData.scala
+++ b/modules/processes/src/test/scala/cards/nine/processes/collections/TestData.scala
@@ -33,7 +33,7 @@ private[collections] object TestData {
 
   val addedPackagesCount = 2
 
-  val androidId = AndroidId("50a4dbf7-85a2-4875-8c75-7232c237808c")
+  val androidId = AndroidId("aaaaaaaaaaaaaaaa")
 
   val appCategory = "COUNTRY"
 
@@ -55,7 +55,7 @@ private[collections] object TestData {
 
   val countryName = "United States"
 
-  val deviceToken = DeviceToken("5d56922c-5257-4392-817e-503166cd7afd")
+  val deviceToken = DeviceToken("77777777-7777-7777-7777-777777777777")
 
   val failure = 0
 
@@ -65,7 +65,7 @@ private[collections] object TestData {
 
   val localization = Localization("en-EN")
 
-  val messageId = "a000dcbd-5419-446f-b2c6-6eaefd88480c"
+  val messageId = "55555555-5555"
 
   val millis = 1453226400000l
 
@@ -79,7 +79,7 @@ private[collections] object TestData {
 
   val pageParams = Page(pageNumber, pageSize)
 
-  val publicIdentifier = "40daf308-fecf-4228-9262-a712d783cf49"
+  val publicIdentifier = "77777777-7777"
 
   val publishedOnDatetime = new DateTime(millis)
 
@@ -97,7 +97,7 @@ private[collections] object TestData {
 
   val success = 1
 
-  val token = "6d54dfed-bbcf-47a5-b8f2-d86cf3320631"
+  val token = "99999999-9999"
 
   val updatedCollectionsCount = 1
 

--- a/modules/services/src/test/scala/cards/nine/services/free/interpreter/googleapi/ServicesSpec.scala
+++ b/modules/services/src/test/scala/cards/nine/services/free/interpreter/googleapi/ServicesSpec.scala
@@ -82,10 +82,10 @@ trait MockGoogleApiServer extends MockServerService {
   val getTokenInfoPath = "/oauth2/v3/tokeninfo"
   val tokenIdParameterName = "id_token"
 
-  val validTokenId = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImVlY2U0NzZiYzdlMDdmYjFlZmVjOTYxZTFhYjI3N2ViYWN"
-  val otherTokenId = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjZkNjQzY2Y5MGI1NTgyOTg0YjRlZTY3MjI4NGMzMzI0ZTg"
-  val wrongTokenId = "eyJpc3MiOiJhY2NvdW50cy5nb29nbGUuY29tIiwiYXRfaGFzaCI6Im1pS1FDOGpGajhGRkF4RG9"
-  val failingTokenId = "1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDYyMjI2OTM3MTk4NjQ5NzA3MzciLCJlbWFpbF92ZX"
+  val validTokenId = "validTokenId"
+  val otherTokenId = "otherTokenId"
+  val wrongTokenId = "wrongTokenId"
+  val failingTokenId = "failingTokenId"
 
   mockServer.when(
     request

--- a/modules/services/src/test/scala/cards/nine/services/persistence/DomainDatabaseContext.scala
+++ b/modules/services/src/test/scala/cards/nine/services/persistence/DomainDatabaseContext.scala
@@ -105,7 +105,7 @@ trait PersistenceDatabaseContext extends BasicDatabaseContext {
 
 trait DomainDatabaseContext extends BasicDatabaseContext {
 
-  val deviceToken: Option[String] = Option("d9f48907-0374-4b3a-89ec-433bd64de2e5")
+  val deviceToken: Option[String] = Option("dddddddd-dddd-bbbb-bbbb-bbbbbbbbbbbb")
   val emptyDeviceToken: Option[String] = None
 
   val deleteAllRows: ConnectionIO[Unit] = for {


### PR DESCRIPTION
We simplify some mocks in the test code, to make it clear that they
are mocks and to ensure we do not use any personal information.
We leave the external data needed for tests to environment variables.


