### PR TITLE
9C-229-1 Migrate the Cache service in GooglePlay 

### DIFF
--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/processes/GooglePlayApp.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/processes/GooglePlayApp.scala
@@ -22,12 +22,12 @@ import cats.~>
 object GooglePlayApp {
 
   type GooglePlayAppC01[A] = Coproduct[GoogleApi.Ops, WebScraper.Ops, A]
-  type GooglePlayApp[A] = Coproduct[Cache.Ops, GooglePlayAppC01, A]
+  type GooglePlayApp[A] = Coproduct[Cache.Op, GooglePlayAppC01, A]
 
   object Interpreters {
     def apply[F[_]](
       googleApiInt: GoogleApi.Ops ~> F,
-      cacheInt: Cache.Ops ~> F,
+      cacheInt: Cache.Op ~> F,
       webScrapperInt: WebScraper.Ops ~> F
     ): (GooglePlayApp ~> F) = {
       val interpreters01: (GooglePlayAppC01 ~> F) = googleApiInt or webScrapperInt

--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/processes/Wiring.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/processes/Wiring.scala
@@ -60,7 +60,7 @@ class Wiring(
     interp andThen toTask
   }
 
-  val cacheInt: Cache.Ops ~> Task = {
+  val cacheInt: Cache.Op ~> Task = {
     val toTask = RedisOpsToTask(config.redis)
     new CacheInterpreter() andThen toTask
   }

--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/algebra/Cache.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/algebra/Cache.scala
@@ -15,64 +15,19 @@
  */
 package cards.nine.googleplay.service.free.algebra
 
-import cats.free.{ Free, Inject }
 import cards.nine.domain.application.{ FullCard, Package }
+import freestyle._
 
-object Cache {
-
-  sealed trait Ops[A]
-
-  case class GetValid(pack: Package) extends Ops[Option[FullCard]]
-
-  case class GetValidMany(packages: List[Package]) extends Ops[List[FullCard]]
-
-  case class PutResolved(card: FullCard) extends Ops[Unit]
-
-  case class PutResolvedMany(cards: List[FullCard]) extends Ops[Unit]
-
-  case class PutPermanent(card: FullCard) extends Ops[Unit]
-
-  case class SetToPending(pack: Package) extends Ops[Unit]
-
-  case class SetToPendingMany(packages: List[Package]) extends Ops[Unit]
-
-  case class AddError(`package`: Package) extends Ops[Unit]
-
-  case class AddErrorMany(packages: List[Package]) extends Ops[Unit]
-
-  case class ListPending(limit: Int) extends Ops[List[Package]]
-
-  class Service[F[_]](implicit I: Inject[Ops, F]) {
-
-    def getValid(pack: Package): Free[F, Option[FullCard]] = Free.inject[Ops, F](GetValid(pack))
-
-    def getValidMany(packages: List[Package]): Free[F, List[FullCard]] =
-      Free.inject[Ops, F](GetValidMany(packages))
-
-    def putResolved(card: FullCard): Free[F, Unit] = Free.inject[Ops, F](PutResolved(card))
-
-    def putResolvedMany(cards: List[FullCard]): Free[F, Unit] =
-      Free.inject[Ops, F](PutResolvedMany(cards))
-
-    def putPermanent(card: FullCard): Free[F, Unit] =
-      Free.inject[Ops, F](PutPermanent(card))
-
-    def setToPending(pack: Package): Free[F, Unit] =
-      Free.inject[Ops, F](SetToPending(pack))
-
-    def setToPendingMany(packages: List[Package]): Free[F, Unit] =
-      Free.inject[Ops, F](SetToPendingMany(packages))
-
-    def addError(pack: Package): Free[F, Unit] = Free.inject[Ops, F](AddError(pack))
-
-    def addErrorMany(packages: List[Package]): Free[F, Unit] = Free.inject[Ops, F](AddErrorMany(packages))
-
-    def listPending(limit: Int): Free[F, List[Package]] = Free.inject[Ops, F](ListPending(limit))
-
-  }
-
-  object Service {
-    implicit def service[F[_]](implicit I: Inject[Ops, F]): Service[F] = new Service[F]
-  }
-
+@free trait Cache {
+  def getValid(pack: Package): FS[Option[FullCard]]
+  def getValidMany(packages: List[Package]): FS[List[FullCard]]
+  def putResolved(card: FullCard): FS[Unit]
+  def putResolvedMany(cards: List[FullCard]): FS[Unit]
+  def putPermanent(card: FullCard): FS[Unit]
+  def setToPending(pack: Package): FS[Unit]
+  def setToPendingMany(packs: List[Package]): FS[Unit]
+  def addError(pack: Package): FS[Unit]
+  def addErrorMany(packs: List[Package]): FS[Unit]
+  def listPending(limit: Int): FS[List[Package]]
 }
+

--- a/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/cache/CacheInterpreter.scala
+++ b/modules/googleplay/src/main/scala/cards/nine/googleplay/service/free/interpreter/cache/CacheInterpreter.scala
@@ -16,9 +16,8 @@
 package cards.nine.googleplay.service.free.interpreter.cache
 
 import cards.nine.commons.redis._
-import cards.nine.domain.application.Package
-import cards.nine.googleplay.service.free.algebra.Cache._
-import cats.~>
+import cards.nine.domain.application.{ FullCard, Package }
+import cards.nine.googleplay.service.free.algebra.Cache
 import cats.instances.list._
 import cats.syntax.cartesian._
 import cats.syntax.functor._
@@ -26,7 +25,7 @@ import cats.syntax.traverse._
 import org.joda.time.{ DateTime, DateTimeZone }
 import scala.concurrent.ExecutionContext
 
-class CacheInterpreter(implicit ec: ExecutionContext) extends (Ops ~> RedisOps) {
+class CacheInterpreter(implicit ec: ExecutionContext) extends Cache.Handler[RedisOps] {
 
   import Formats._
   import RedisOps._
@@ -37,47 +36,51 @@ class CacheInterpreter(implicit ec: ExecutionContext) extends (Ops ~> RedisOps) 
 
   private[this] val pendingSet: CacheSet[PendingQueueKey.type, Package] = new CacheSet(PendingQueueKey)
 
-  def apply[A](ops: Ops[A]): RedisOps[A] = ops match {
-
-    case GetValid(pack) ⇒
-      val keys = List(CacheKey.resolved(pack), CacheKey.permanent(pack))
-      wrap.mget(keys).map(_.flatMap(_.card).headOption)
-
-    case GetValidMany(packages) ⇒
-      val keys = (packages map CacheKey.resolved) ++ (packages map CacheKey.permanent)
-      wrap.mget(keys).map(_.flatMap(_.card))
-
-    case PutResolved(card) ⇒
-      val pack = card.packageName
-      pendingSet.remove(pack) *> removeError(pack) *> wrap.put(CacheEntry.resolved(card))
-
-    case PutResolvedMany(cards) ⇒
-      val packs = cards.map(_.packageName)
-      wrap.mput(cards map CacheEntry.resolved) *> removeErrorMany(packs) *> pendingSet.remove(packs)
-
-    case PutPermanent(card) ⇒
-      val pack = card.packageName
-      pendingSet.remove(pack) *> removeError(pack) *> wrap.put(CacheEntry.permanent(card))
-
-    case SetToPending(pack) ⇒
-      removeError(pack) *> pendingSet.insert(pack)
-
-    case SetToPendingMany(packages) ⇒
-      removeErrorMany(packages) *> pendingSet.insert(packages)
-
-    case AddError(pack) ⇒
-      val now = DateTime.now(DateTimeZone.UTC)
-      pendingSet.remove(pack) *> errorCache.enqueue(CacheKey.error(pack), now)
-
-    case AddErrorMany(packages) ⇒
-      val now = DateTime.now(DateTimeZone.UTC)
-      val putErrors = packages.traverse[RedisOps, Unit] {
-        pack ⇒ errorCache.enqueue(CacheKey.error(pack), now)
-      }
-      putErrors *> pendingSet.remove(packages)
-
-    case ListPending(num) ⇒ pendingSet.extractMany(num)
+  override def getValid(pack: Package): RedisOps[Option[FullCard]] = {
+    val keys = List(CacheKey.resolved(pack), CacheKey.permanent(pack))
+    wrap.mget(keys).map(_.flatMap(_.card).headOption)
   }
+
+  override def getValidMany(packages: List[Package]) = {
+    val keys = (packages map CacheKey.resolved) ++ (packages map CacheKey.permanent)
+    wrap.mget(keys).map(_.flatMap(_.card))
+  }
+
+  override def putResolved(card: FullCard): RedisOps[Unit] = {
+    val pack = card.packageName
+    pendingSet.remove(pack) *> removeError(pack) *> wrap.put(CacheEntry.resolved(card))
+  }
+
+  override def putResolvedMany(cards: List[FullCard]): RedisOps[Unit] = {
+    val packs = cards.map(_.packageName)
+    wrap.mput(cards map CacheEntry.resolved) *> removeErrorMany(packs) *> pendingSet.remove(packs)
+  }
+
+  override def putPermanent(card: FullCard): RedisOps[Unit] = {
+    val pack = card.packageName
+    pendingSet.remove(pack) *> removeError(pack) *> wrap.put(CacheEntry.permanent(card))
+  }
+
+  override def setToPending(pack: Package): RedisOps[Unit] =
+    removeError(pack) *> pendingSet.insert(pack)
+
+  override def setToPendingMany(packages: List[Package]): RedisOps[Unit] =
+    removeErrorMany(packages) *> pendingSet.insert(packages)
+
+  override def addError(pack: Package): RedisOps[Unit] = {
+    val now = DateTime.now(DateTimeZone.UTC)
+    pendingSet.remove(pack) *> errorCache.enqueue(CacheKey.error(pack), now)
+  }
+
+  override def addErrorMany(packages: List[Package]): RedisOps[Unit] = {
+    val now = DateTime.now(DateTimeZone.UTC)
+    val putErrors = packages.traverse[RedisOps, Unit] {
+      pack ⇒ errorCache.enqueue(CacheKey.error(pack), now)
+    }
+    putErrors *> pendingSet.remove(packages)
+  }
+
+  override def listPending(num: Int): RedisOps[List[Package]] = pendingSet.extractMany(num)
 
   private[this] def removeError(pack: Package): RedisOps[Unit] =
     errorCache.delete(CacheKey.error(pack))

--- a/modules/googleplay/src/test/scala/cards/nine/googleplay/processes/CardsProcessesSpec.scala
+++ b/modules/googleplay/src/test/scala/cards/nine/googleplay/processes/CardsProcessesSpec.scala
@@ -41,7 +41,7 @@ class CardsProcessesSpec
   val apiGoogleInt: ApiAlg.Ops ~> Id = ApiInt.MockInterpreter(apiGoogleIntServer)
 
   val cacheIntServer: CacheInt.InterpreterServer[Id] = mock[CacheInt.InterpreterServer[Id]]
-  val cacheInt: CacheAlg.Ops ~> Id = CacheInt.MockInterpreter(cacheIntServer)
+  val cacheInt: CacheAlg.Handler[Id] = CacheInt.MockInterpreter(cacheIntServer)
 
   val webScrapperIntServer: WebInt.InterpreterServer[Id] = mock[WebInt.InterpreterServer[Id]]
   val webScrapperInt: WebAlg.Ops ~> Id = WebInt.MockInterpreter(webScrapperIntServer)

--- a/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/cache/InterpreterSpec.scala
+++ b/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/cache/InterpreterSpec.scala
@@ -18,8 +18,6 @@ package cards.nine.googleplay.service.free.interpreter.cache
 import cards.nine.commons.redis.{ RedisOps, TestUtils }
 import cards.nine.domain.application.{ FullCard, Package }
 import cards.nine.domain.ScalaCheck._
-import cards.nine.googleplay.service.free.algebra.Cache
-import cards.nine.googleplay.service.free.algebra.Cache._
 import cards.nine.googleplay.util.{ ScalaCheck ⇒ CustomArbitrary }
 import org.joda.time.{ DateTime, DateTimeZone }
 import org.scalacheck.{ Arbitrary, Gen }
@@ -56,9 +54,9 @@ class InterpreterSpec
 
     val cc = new CacheInterpreter()
 
-    def eval[A](op: RedisOps[A]) = op(redisClient).unsafePerformSync
+    def eval[A](op: RedisOps[A]): A = op(redisClient).unsafePerformSync
 
-    def evalWithDelay[A](op: RedisOps[A], delay: Duration) = op(redisClient).after(delay).unsafePerformSync
+    def evalWithDelay[A](op: RedisOps[A], delay: Duration): A = op(redisClient).after(delay).unsafePerformSync
 
     def pendingKey(pack: Package): String = s"${pack.value}:Pending"
     def resolvedKey(pack: Package): String = s"${pack.value}:Resolved"

--- a/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/cache/InterpreterSpec.scala
+++ b/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/cache/InterpreterSpec.scala
@@ -15,9 +15,10 @@
  */
 package cards.nine.googleplay.service.free.interpreter.cache
 
-import cards.nine.commons.redis.TestUtils
+import cards.nine.commons.redis.{ RedisOps, TestUtils }
 import cards.nine.domain.application.{ FullCard, Package }
 import cards.nine.domain.ScalaCheck._
+import cards.nine.googleplay.service.free.algebra.Cache
 import cards.nine.googleplay.service.free.algebra.Cache._
 import cards.nine.googleplay.util.{ ScalaCheck ⇒ CustomArbitrary }
 import org.joda.time.{ DateTime, DateTimeZone }
@@ -53,11 +54,11 @@ class InterpreterSpec
 
     import scala.concurrent.ExecutionContext.Implicits.global
 
-    val interpreter = new CacheInterpreter()
+    val cc = new CacheInterpreter()
 
-    def eval[A](op: Ops[A]) = interpreter(op)(redisClient).unsafePerformSync
+    def eval[A](op: RedisOps[A]) = op(redisClient).unsafePerformSync
 
-    def evalWithDelay[A](op: Ops[A], delay: Duration) = interpreter(op)(redisClient).after(delay).unsafePerformSync
+    def evalWithDelay[A](op: RedisOps[A], delay: Duration) = op(redisClient).after(delay).unsafePerformSync
 
     def pendingKey(pack: Package): String = s"${pack.value}:Pending"
     def resolvedKey(pack: Package): String = s"${pack.value}:Resolved"
@@ -141,7 +142,7 @@ class InterpreterSpec
       prop { pack: Package ⇒
         flush
 
-        eval(GetValid(pack)) must beNone
+        eval(cc.getValid(pack)) must beNone
       }
 
     "return None if the cache only contains Error or Pending entries for the package" >>
@@ -150,7 +151,7 @@ class InterpreterSpec
         putPending(pack)
         putError(pack, date)
 
-        eval(GetValid(pack)) must beNone
+        eval(cc.getValid(pack)) must beNone
       }
 
     "return Some(e) if the cache contains a Resolved entry" >>
@@ -158,7 +159,7 @@ class InterpreterSpec
         flush
         putEntry(CacheEntry.resolved(card))
 
-        eval(GetValid(card.packageName)) must beSome(card)
+        eval(cc.getValid(card.packageName)) must beSome(card)
       }
 
     "return Some(e) if the cache contains a Permanent entry" >>
@@ -166,7 +167,7 @@ class InterpreterSpec
         flush
         putEntry(CacheEntry.permanent(card))
 
-        eval(GetValid(card.packageName)) must beSome(card)
+        eval(cc.getValid(card.packageName)) must beSome(card)
       }
   }
 
@@ -176,7 +177,7 @@ class InterpreterSpec
       prop { packages: List[Package] ⇒
         flush
 
-        eval(GetValidMany(packages)) must beEmpty
+        eval(cc.getValidMany(packages)) must beEmpty
       }
 
     "return an empty list if the cache only contains the packages as Errors" >>
@@ -184,7 +185,7 @@ class InterpreterSpec
         flush
         packages foreach { p ⇒ putError(p, date) }
 
-        eval(GetValidMany(packages)) must beEmpty
+        eval(cc.getValidMany(packages)) must beEmpty
       }
 
     "return an empty list if the cache only contains the packages as Pending" >>
@@ -192,7 +193,7 @@ class InterpreterSpec
         flush
         putPendings(packages)
 
-        eval(GetValidMany(packages)) must beEmpty
+        eval(cc.getValidMany(packages)) must beEmpty
       }
 
     "return a list of cards if the cache contains a Resolved entry" >>
@@ -200,7 +201,7 @@ class InterpreterSpec
         flush
         putEntries(cards map CacheEntry.resolved)
 
-        eval(GetValidMany(cards map (_.packageName))) must containTheSameElementsAs(cards)
+        eval(cc.getValidMany(cards map (_.packageName))) must containTheSameElementsAs(cards)
       }
 
     "return a list of cards if the cache contains a Permanent entry" >>
@@ -208,7 +209,7 @@ class InterpreterSpec
         flush
         putEntries(cards map CacheEntry.permanent)
 
-        eval(GetValidMany(cards map (_.packageName))) must containTheSameElementsAs(cards)
+        eval(cc.getValidMany(cards map (_.packageName))) must containTheSameElementsAs(cards)
       }
   }
 
@@ -217,7 +218,7 @@ class InterpreterSpec
     "add a package as resolved" >>
       prop { card: FullCard ⇒
         flush
-        eval(PutResolved(card))
+        eval(cc.putResolved(card))
 
         existsEntry(resolvedKey(card.packageName)) must beTrue
       }
@@ -225,7 +226,7 @@ class InterpreterSpec
     "add no other key as resolved" >>
       prop { (card: FullCard, pack: Package) ⇒
         flush
-        eval(PutResolved(card))
+        eval(cc.putResolved(card))
 
         existsEntry(resolvedKey(pack)) must beFalse
       }
@@ -233,7 +234,7 @@ class InterpreterSpec
     "add no key as pending or error" >>
       prop { card: FullCard ⇒
         flush
-        eval(PutResolved(card))
+        eval(cc.putResolved(card))
 
         getPending() must beEmpty
         getKeys(allByType(Error)) must beEmpty
@@ -244,7 +245,7 @@ class InterpreterSpec
         flush
         putPending(card.packageName)
         putError(card.packageName, date)
-        eval(PutResolved(card))
+        eval(cc.putResolved(card))
         getPending() must beEmpty
         getKeys(allByType(Error)) must beEmpty
         dumpQueue() must beEmpty
@@ -254,8 +255,8 @@ class InterpreterSpec
       prop { (card: FullCard) ⇒
         flush
         val newCard = card.copy(title = card.title.reverse, free = !card.free)
-        eval(PutResolved(card))
-        eval(PutResolved(newCard))
+        eval(cc.putResolved(card))
+        eval(cc.putResolved(newCard))
 
         getKeys(allByType(Resolved)) must haveSize(1)
         getCacheValue(resolvedKey(card.packageName)) must_=== Option(CacheVal(Option(newCard)))
@@ -267,7 +268,7 @@ class InterpreterSpec
     "add a list of packages as resolved" >>
       prop { cards: List[FullCard] ⇒
         flush
-        eval(PutResolvedMany(cards))
+        eval(cc.putResolvedMany(cards))
         cards.map(c ⇒ resolvedKey(c.packageName))
           .filter(existsEntry _) must haveSize(cards.size)
       }
@@ -275,7 +276,7 @@ class InterpreterSpec
     "add no other key as resolved" >>
       prop { (cards: List[FullCard], pack: Package) ⇒
         flush
-        eval(PutResolvedMany(cards))
+        eval(cc.putResolvedMany(cards))
 
         existsEntry(resolvedKey(pack)) must beFalse
       }
@@ -283,7 +284,7 @@ class InterpreterSpec
     "add no key as pending or error" >>
       prop { cards: List[FullCard] ⇒
         flush
-        eval(PutResolvedMany(cards))
+        eval(cc.putResolvedMany(cards))
 
         getPending() must beEmpty
         getKeys(allByType(Error)) must beEmpty
@@ -293,8 +294,8 @@ class InterpreterSpec
       prop { (cards: List[FullCard]) ⇒
         flush
         val newCards = cards map (c ⇒ c.copy(title = c.title.reverse, free = !c.free))
-        eval(PutResolvedMany(cards))
-        evalWithDelay(PutResolvedMany(newCards), 1.millis)
+        eval(cc.putResolvedMany(cards))
+        evalWithDelay(cc.putResolvedMany(newCards), 1.millis)
 
         val values = getCacheValues(cards map (c ⇒ resolvedKey(c.packageName)))
 
@@ -307,7 +308,7 @@ class InterpreterSpec
     "add a package as permanent" >>
       prop { card: FullCard ⇒
         flush
-        eval(PutPermanent(card))
+        eval(cc.putPermanent(card))
 
         existsEntry(permanentKey(card.packageName)) must beTrue
       }
@@ -315,7 +316,7 @@ class InterpreterSpec
     "add no other key as permanent" >>
       prop { (card: FullCard, pack: Package) ⇒
         flush
-        eval(PutPermanent(card))
+        eval(cc.putPermanent(card))
 
         existsEntry(permanentKey(pack)) must beFalse
       }
@@ -323,7 +324,7 @@ class InterpreterSpec
     "add no key as pending or error" >>
       prop { card: FullCard ⇒
         flush
-        eval(PutPermanent(card))
+        eval(cc.putPermanent(card))
         getPending() must beEmpty
         getKeys(allByType(Error)) must beEmpty
       }
@@ -333,7 +334,7 @@ class InterpreterSpec
         flush
         putPending(card.packageName)
         putError(card.packageName, date)
-        eval(PutPermanent(card))
+        eval(cc.putPermanent(card))
         getPending() must beEmpty
         getKeys(allByType(Error)) must beEmpty
         dumpQueue() must beEmpty
@@ -343,8 +344,8 @@ class InterpreterSpec
       prop { (card: FullCard) ⇒
         flush
         val newCard = card.copy(title = card.title.reverse, free = !card.free)
-        eval(PutPermanent(card))
-        eval(PutPermanent(newCard))
+        eval(cc.putPermanent(card))
+        eval(cc.putPermanent(newCard))
 
         getKeys(allByType(Permanent)) must haveSize(1)
         getCacheValue(permanentKey(card.packageName)) must_=== Option(CacheVal(Option(newCard)))
@@ -355,7 +356,7 @@ class InterpreterSpec
     "add a package as error" >>
       prop { pack: Package ⇒
         flush
-        eval(AddError(pack))
+        eval(cc.addError(pack))
 
         getKeys(allByPackageAndType(pack, Error)) must not be empty
       }
@@ -363,7 +364,7 @@ class InterpreterSpec
     "add no key as resolved or pending" >>
       prop { pack: Package ⇒
         flush
-        eval(AddError(pack))
+        eval(cc.addError(pack))
 
         getKeys(allByType(Resolved)) must beEmpty
         getPending() must beEmpty
@@ -373,7 +374,7 @@ class InterpreterSpec
       prop { pack: Package ⇒
         flush
         putPending(pack)
-        eval(AddError(pack))
+        eval(cc.addError(pack))
         getPending() must beEmpty
         dumpQueue() must beEmpty
       }
@@ -381,8 +382,8 @@ class InterpreterSpec
     "allow adding several error entries for package with different dates" >>
       prop { pack: Package ⇒
         flush
-        eval(AddError(pack))
-        evalWithDelay(AddError(pack), 1.millis)
+        eval(cc.addError(pack))
+        evalWithDelay(cc.addError(pack), 1.millis)
         getKeys(allByType(Error)) must haveSize(1)
       }
   }
@@ -391,7 +392,7 @@ class InterpreterSpec
     "add a list of packages as error" >>
       prop { packages: List[Package] ⇒
         flush
-        eval(AddErrorMany(packages))
+        eval(cc.addErrorMany(packages))
 
         getKeys(allByType(Error)) must haveSize(packages.size)
       }
@@ -399,7 +400,7 @@ class InterpreterSpec
     "add no key as resolved or pending" >>
       prop { packages: List[Package] ⇒
         flush
-        eval(AddErrorMany(packages))
+        eval(cc.addErrorMany(packages))
 
         getPending() must beEmpty
         getKeys(allByType(Resolved)) must beEmpty
@@ -409,7 +410,7 @@ class InterpreterSpec
       prop { packages: List[Package] ⇒
         flush
         putPendings(packages)
-        eval(AddErrorMany(packages))
+        eval(cc.addErrorMany(packages))
         getPending() must beEmpty
         dumpQueue() must beEmpty
       }
@@ -417,8 +418,8 @@ class InterpreterSpec
     "allow adding several errors with different dates" >>
       prop { packages: List[Package] ⇒
         flush
-        eval(AddErrorMany(packages))
-        evalWithDelay(AddErrorMany(packages), 2.millis)
+        eval(cc.addErrorMany(packages))
+        evalWithDelay(cc.addErrorMany(packages), 2.millis)
         getKeys(allByType(Error)) must haveSize(packages.size)
       }
   }
@@ -438,7 +439,7 @@ class InterpreterSpec
       prop { testData: ListPendingTestData ⇒
         flush
         putPendings(testData.pendingPackages)
-        val list = eval(ListPending(testData.limit))
+        val list = eval(cc.listPending(testData.limit))
         list must contain(atMost(testData.pendingPackages: _*))
         list must haveSize(testData.limit)
       }

--- a/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/cache/MockInterpreter.scala
+++ b/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/cache/MockInterpreter.scala
@@ -17,7 +17,6 @@ package cards.nine.googleplay.service.free.interpreter.cache
 
 import cards.nine.domain.application.{ FullCard, Package }
 import cards.nine.googleplay.service.free.algebra.Cache._
-import cats.~>
 
 trait InterpreterServer[F[_]] {
   def getValid(pack: Package): F[Option[FullCard]]
@@ -33,7 +32,6 @@ trait InterpreterServer[F[_]] {
 }
 
 case class MockInterpreter[F[_]](server: InterpreterServer[F]) extends Handler[F] {
-
   def getValid(pack: Package) = server.getValid(pack)
   def getValidMany(packages: List[Package]) = server.getValidMany(packages)
   def putResolved(card: FullCard) = server.putResolved(card)
@@ -44,5 +42,4 @@ case class MockInterpreter[F[_]](server: InterpreterServer[F]) extends Handler[F
   def addError(pack: Package) = server.addError(pack)
   def addErrorMany(packs: List[Package]) = server.addErrorMany(packs)
   def listPending(limit: Int) = server.listPending(limit)
-
 }

--- a/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/cache/MockInterpreter.scala
+++ b/modules/googleplay/src/test/scala/cards/nine/googleplay/service/free/interpreter/cache/MockInterpreter.scala
@@ -32,19 +32,17 @@ trait InterpreterServer[F[_]] {
   def listPending(num: Int): F[List[Package]]
 }
 
-case class MockInterpreter[F[_]](server: InterpreterServer[F]) extends (Ops ~> F) {
+case class MockInterpreter[F[_]](server: InterpreterServer[F]) extends Handler[F] {
 
-  override def apply[A](ops: Ops[A]) = ops match {
-    case GetValid(pack) ⇒ server.getValid(pack)
-    case GetValidMany(packages) ⇒ server.getValidMany(packages)
-    case PutResolved(card) ⇒ server.putResolved(card)
-    case PutResolvedMany(packages) ⇒ server.putResolvedMany(packages)
-    case PutPermanent(card) ⇒ server.putPermanent(card)
-    case SetToPending(pack) ⇒ server.setToPending(pack)
-    case SetToPendingMany(packages) ⇒ server.setToPendingMany(packages)
-    case AddError(pack) ⇒ server.addError(pack)
-    case AddErrorMany(packages) ⇒ server.addErrorMany(packages)
-    case ListPending(num) ⇒ server.listPending(num)
-  }
+  def getValid(pack: Package) = server.getValid(pack)
+  def getValidMany(packages: List[Package]) = server.getValidMany(packages)
+  def putResolved(card: FullCard) = server.putResolved(card)
+  def putResolvedMany(cards: List[FullCard]) = server.putResolvedMany(cards)
+  def putPermanent(card: FullCard) = server.putPermanent(card)
+  def setToPending(pack: Package) = server.setToPending(pack)
+  def setToPendingMany(packs: List[Package]) = server.setToPendingMany(packs)
+  def addError(pack: Package) = server.addError(pack)
+  def addErrorMany(packs: List[Package]) = server.addErrorMany(packs)
+  def listPending(limit: Int) = server.listPending(limit)
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,6 +47,7 @@ object Dependencies {
   private val sprayTestKit = spray("-testkit") % "test" exclude("org.specs2", "specs2_2.11")
   private val tagSoup = "org.ccil.cowan.tagsoup" % "tagsoup" % Versions.tagSoup
   private val typesafeConfig = "com.typesafe" % "config" % Versions.typesafeConfig
+  private val freestyle = "io.frees" %% "freestyle"              % Versions.freestyle
 
   val baseDeps = Seq(
     hasher,
@@ -127,6 +128,7 @@ object Dependencies {
     newRelic,
     scredis,
     scalacheckShapeless,
+    freestyle,
     specs2Core,
     specs2("-matcher-extra"),
     specs2("-mock"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,7 @@ object Dependencies {
   private val cats = "org.typelevel" %% "cats" % Versions.cats
   private val embeddedRedis = "com.orange.redis-embedded" % "embedded-redis" % Versions.embeddedRedis % "test"
   private val flywaydbCore = "org.flywaydb" % "flyway-core" % Versions.flywaydb
+  private val freestyle = "io.frees" %% "freestyle" % Versions.freestyle
   private val googleApiClient = "com.google.api-client" % "google-api-client" % Versions.googleApiClient exclude("com.google.guava", "*")
   private val hasher = "com.roundeights" %% "hasher" % Versions.hasher
   private val http4sClient = "org.http4s" %% "http4s-blaze-client" % Versions.http4s
@@ -47,7 +48,6 @@ object Dependencies {
   private val sprayTestKit = spray("-testkit") % "test" exclude("org.specs2", "specs2_2.11")
   private val tagSoup = "org.ccil.cowan.tagsoup" % "tagsoup" % Versions.tagSoup
   private val typesafeConfig = "com.typesafe" % "config" % Versions.typesafeConfig
-  private val freestyle = "io.frees" %% "freestyle"              % Versions.freestyle
 
   val baseDeps = Seq(
     hasher,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -23,13 +23,14 @@ trait Settings {
 
   lazy val projectSettings: Seq[Def.Setting[_]] = Seq(
     addCompilerPlugin("org.spire-math" %% "kind-projector" % Versions.kindProjector),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
     scalaVersion := Versions.scala,
     organization := "com.fortysevendeg",
     organizationName := "47 Degrees",
     organizationHomepage := Some(new URL("http://47deg.com")),
     version := Versions.buildVersion,
     conflictWarning := ConflictWarning.disable,
-    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:higherKinds", "-language:implicitConversions", "-Ywarn-unused-import", "-Xfatal-warnings"),
+    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:higherKinds", "-language:implicitConversions", "-Ywarn-unused-import"),
     javaOptions in Test ++= Seq("-XX:MaxPermSize=128m", "-Xms512m", "-Xmx512m"),
     sbt.Keys.fork in Test := false,
     publishMavenStyle := true,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -20,11 +20,12 @@ object Versions {
 
   // Core Libs
   val akka = "2.4.8"
-  val cats = "0.8.1"
-  val circe = "0.6.0"
+  val cats = "0.9.0"
+  val circe = "0.8.0"
   val doobie = "0.3.0"
   val enumeratum = "1.5.1"
   val flywaydb = "3.2.1"
+  val freestyle = "0.1.1"
   val googleApiClient = "1.20.0"
   val hasher = "1.2.0"
   val http4s = "0.15.0a"


### PR DESCRIPTION
This is our first migration attempt to FreeStyle, under Issue #229. As a simple starting point, we migrate the Cache algebra in the `googleplay` module to use Freestyle. Some things to mention: 

* We add the dependency of `freestyle`. Because this dependency upgraded `cats` to a version that is somehow incompatible with the version of `circe`, we have upgraded them both.
* The `@free` macro introduces some unused imports, so we needed to disable the `fatal warnings` flag.
* In the processes we introduce a few operations to move from plain `Free` to `FreeS`.