### PR TITLE
9C-229-2 Shared Collections

### DIFF
--- a/modules/processes/src/main/scala/cards/nine/processes/NineCardsServices.scala
+++ b/modules/processes/src/main/scala/cards/nine/processes/NineCardsServices.scala
@@ -28,7 +28,7 @@ object NineCardsServices {
 
   type NineCardsServicesC08[A] = Coproduct[GoogleOAuth.Ops, User.Ops, A]
   type NineCardsServicesC07[A] = Coproduct[Subscription.Ops, NineCardsServicesC08, A]
-  type NineCardsServicesC06[A] = Coproduct[SharedCollection.Ops, NineCardsServicesC07, A]
+  type NineCardsServicesC06[A] = Coproduct[Collection.Op, NineCardsServicesC07, A]
   type NineCardsServicesC05[A] = Coproduct[Ranking.Ops, NineCardsServicesC06, A]
   type NineCardsServicesC04[A] = Coproduct[Country.Ops, NineCardsServicesC05, A]
   type NineCardsServicesC03[A] = Coproduct[GooglePlay.Ops, NineCardsServicesC04, A]

--- a/modules/services/src/main/scala/cards/nine/services/free/algebra/SharedCollection.scala
+++ b/modules/services/src/main/scala/cards/nine/services/free/algebra/SharedCollection.scala
@@ -15,68 +15,21 @@
  */
 package cards.nine.services.free.algebra
 
-import cards.nine.commons.NineCardsService
-import cards.nine.commons.NineCardsService.{ NineCardsService, Result }
+import cards.nine.commons.NineCardsService.Result
 import cards.nine.domain.application.Package
 import cards.nine.domain.pagination.Page
 import cards.nine.services.free.domain
 import cards.nine.services.free.interpreter.collection.Services.SharedCollectionData
-import cats.free.:<:
+import freestyle._
 
-object SharedCollection {
-
-  sealed trait Ops[A]
-
-  case class Add(collection: SharedCollectionData) extends Ops[Result[domain.SharedCollection]]
-
-  case class GetById(id: Long) extends Ops[Result[domain.SharedCollection]]
-
-  case class GetByPublicId(publicId: String) extends Ops[Result[domain.SharedCollection]]
-
-  case class GetByUser(user: Long) extends Ops[Result[List[domain.SharedCollectionWithAggregatedInfo]]]
-
-  case class GetLatestByCategory(category: String, pageParams: Page) extends Ops[Result[List[domain.SharedCollection]]]
-
-  case class GetTopByCategory(category: String, pageParams: Page) extends Ops[Result[List[domain.SharedCollection]]]
-
-  case class IncreaseViewsByOne(id: Long) extends Ops[Result[Int]]
-
-  case class Update(id: Long, title: String) extends Ops[Result[Int]]
-
-  case class UpdatePackages(collection: Long, packages: List[Package]) extends Ops[Result[(List[Package], List[Package])]]
-
-  class Services[F[_]](implicit I: Ops :<: F) {
-
-    def add(collection: SharedCollectionData): NineCardsService[F, domain.SharedCollection] =
-      NineCardsService(Add(collection))
-
-    def getById(id: Long): NineCardsService[F, domain.SharedCollection] =
-      NineCardsService(GetById(id))
-
-    def getByPublicId(publicId: String): NineCardsService[F, domain.SharedCollection] =
-      NineCardsService(GetByPublicId(publicId))
-
-    def getByUser(user: Long): NineCardsService[F, List[domain.SharedCollectionWithAggregatedInfo]] =
-      NineCardsService(GetByUser(user))
-
-    def getLatestByCategory(category: String, pageParams: Page): NineCardsService[F, List[domain.SharedCollection]] =
-      NineCardsService(GetLatestByCategory(category, pageParams))
-
-    def getTopByCategory(category: String, pageParams: Page): NineCardsService[F, List[domain.SharedCollection]] =
-      NineCardsService(GetTopByCategory(category, pageParams))
-
-    def increaseViewsByOne(id: Long): NineCardsService[F, Int] = NineCardsService(IncreaseViewsByOne(id))
-
-    def update(id: Long, title: String): NineCardsService[F, Int] = NineCardsService(Update(id, title))
-
-    def updatePackages(collection: Long, packages: List[Package]): NineCardsService[F, (List[Package], List[Package])] =
-      NineCardsService(UpdatePackages(collection, packages))
-  }
-
-  object Services {
-
-    implicit def services[F[_]](implicit I: Ops :<: F): Services[F] = new Services[F]
-
-  }
-
+@free trait Collection {
+  def add(collection: SharedCollectionData): FS[Result[domain.SharedCollection]]
+  def getById(id: Long): FS[Result[domain.SharedCollection]]
+  def getByPublicId(publicId: String): FS[Result[domain.SharedCollection]]
+  def getByUser(user: Long): FS[Result[List[domain.SharedCollectionWithAggregatedInfo]]]
+  def getLatestByCategory(category: String, pageParams: Page): FS[Result[List[domain.SharedCollection]]]
+  def getTopByCategory(category: String, pageParams: Page): FS[Result[List[domain.SharedCollection]]]
+  def increaseViewsByOne(id: Long): FS[Result[Int]]
+  def update(id: Long, title: String): FS[Result[Int]]
+  def updatePackages(collection: Long, packages: List[Package]): FS[Result[(List[Package], List[Package])]]
 }

--- a/modules/services/src/main/scala/cards/nine/services/free/interpreter/Interpreters.scala
+++ b/modules/services/src/main/scala/cards/nine/services/free/interpreter/Interpreters.scala
@@ -51,7 +51,7 @@ class Interpreters(implicit A: ApplicativeError[Task, Throwable], T: Transactor[
 
   val analyticsInterpreter: (GoogleAnalytics.Ops ~> Task) = AnalyticsServices.services(nineCardsConfiguration.google.analytics)
 
-  val collectionInterpreter: (SharedCollection.Ops ~> Task) = CollectionServices.services.andThen(connectionIO2Task)
+  val collectionInterpreter: (Collection.Op ~> Task) = CollectionServices.services.andThen(connectionIO2Task)
 
   val countryInterpreter: (Country.Ops ~> Task) = CountryServices.services.andThen(connectionIO2Task)
 

--- a/modules/services/src/main/scala/cards/nine/services/free/interpreter/collection/Services.scala
+++ b/modules/services/src/main/scala/cards/nine/services/free/interpreter/collection/Services.scala
@@ -23,7 +23,7 @@ import cards.nine.domain.application.Package
 import cards.nine.domain.pagination.Page
 import cards.nine.services.common.PersistenceService
 import cards.nine.services.common.PersistenceService._
-import cards.nine.services.free.algebra.Collection._
+import cards.nine.services.free.algebra.Collection
 import cards.nine.services.free.domain.SharedCollection.Queries
 import cards.nine.services.free.domain._
 import cards.nine.services.free.interpreter.collection.Services.SharedCollectionData
@@ -36,7 +36,7 @@ import shapeless.syntax.std.product._
 
 class Services(
   collectionPersistence: Persistence[SharedCollection]
-)(implicit connectionIOMonad: Monad[ConnectionIO]) extends Handler[ConnectionIO] {
+)(implicit connectionIOMonad: Monad[ConnectionIO]) extends Collection.Handler[ConnectionIO] {
 
   override def add(data: SharedCollectionData): PersistenceService[SharedCollection] =
     PersistenceService {

--- a/modules/services/src/test/scala/cards/nine/services/free/interpreter/collection/ServicesSpec.scala
+++ b/modules/services/src/test/scala/cards/nine/services/free/interpreter/collection/ServicesSpec.scala
@@ -268,7 +268,7 @@ class ServicesSpec
     "return a SharedCollectionNotFound error if the table is empty" in {
       prop { (publicIdentifier: PublicIdentifier) ⇒
         WithEmptyDatabase {
-          val collection = collectionPersistenceServices.getByPublicIdentifier(
+          val collection = collectionPersistenceServices.getByPublicId(
             publicIdentifier = publicIdentifier.value
           ).transactAndRun
 
@@ -280,7 +280,7 @@ class ServicesSpec
       prop { (userData: UserData, collectionData: SharedCollectionData) ⇒
         WithData(userData, collectionData) { collectionId ⇒
 
-          val collection = collectionPersistenceServices.getByPublicIdentifier(
+          val collection = collectionPersistenceServices.getByPublicId(
             publicIdentifier = collectionData.publicIdentifier
           ).transactAndRun
 
@@ -298,7 +298,7 @@ class ServicesSpec
 
           WithData(userData, collectionData) { _ ⇒
 
-            val collection = collectionPersistenceServices.getByPublicIdentifier(
+            val collection = collectionPersistenceServices.getByPublicId(
               publicIdentifier = collectionData.publicIdentifier.reverse
             ).transactAndRun
 
@@ -473,7 +473,7 @@ class ServicesSpec
     "return 0 updated rows if the table is empty" in {
       prop { (id: Long, title: CollectionTitle) ⇒
         WithEmptyDatabase {
-          val updatedCollectionCount = collectionPersistenceServices.updateCollectionInfo(
+          val updatedCollectionCount = collectionPersistenceServices.update(
             id    = id,
             title = title.value
           ).transactAndRun
@@ -487,7 +487,7 @@ class ServicesSpec
 
         WithData(userData, collectionData) { collectionId ⇒
 
-          collectionPersistenceServices.updateCollectionInfo(
+          collectionPersistenceServices.update(
             id    = collectionId,
             title = newTitle.value
           ).transactAndRun
@@ -506,7 +506,7 @@ class ServicesSpec
 
         WithData(userData, collectionData) { collectionId ⇒
 
-          val updatedCollectionCount = collectionPersistenceServices.updateCollectionInfo(
+          val updatedCollectionCount = collectionPersistenceServices.update(
             id    = collectionId * -1,
             title = newTitle.value
           ).transactAndRun

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,7 @@ object Dependencies {
   private val cats = "org.typelevel" %% "cats" % Versions.cats
   private val embeddedRedis = "com.orange.redis-embedded" % "embedded-redis" % Versions.embeddedRedis % "test"
   private val flywaydbCore = "org.flywaydb" % "flyway-core" % Versions.flywaydb
+  private val freestyle = "io.frees" %% "freestyle" % Versions.freestyle
   private val googleApiClient = "com.google.api-client" % "google-api-client" % Versions.googleApiClient exclude("com.google.guava", "*")
   private val hasher = "com.roundeights" %% "hasher" % Versions.hasher
   private val http4sClient = "org.http4s" %% "http4s-blaze-client" % Versions.http4s
@@ -127,6 +128,7 @@ object Dependencies {
     newRelic,
     scredis,
     scalacheckShapeless,
+    freestyle,
     specs2Core,
     specs2("-matcher-extra"),
     specs2("-mock"),

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -23,13 +23,14 @@ trait Settings {
 
   lazy val projectSettings: Seq[Def.Setting[_]] = Seq(
     addCompilerPlugin("org.spire-math" %% "kind-projector" % Versions.kindProjector),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
     scalaVersion := Versions.scala,
     organization := "com.fortysevendeg",
     organizationName := "47 Degrees",
     organizationHomepage := Some(new URL("http://47deg.com")),
     version := Versions.buildVersion,
     conflictWarning := ConflictWarning.disable,
-    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:higherKinds", "-language:implicitConversions", "-Ywarn-unused-import", "-Xfatal-warnings"),
+    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:higherKinds", "-language:implicitConversions", "-Ywarn-unused-import"),
     javaOptions in Test ++= Seq("-XX:MaxPermSize=128m", "-Xms512m", "-Xmx512m"),
     sbt.Keys.fork in Test := false,
     publishMavenStyle := true,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -20,11 +20,12 @@ object Versions {
 
   // Core Libs
   val akka = "2.4.8"
-  val cats = "0.8.1"
-  val circe = "0.6.0"
+  val cats = "0.9.0"
+  val circe = "0.8.0"
   val doobie = "0.3.0"
   val enumeratum = "1.5.1"
   val flywaydb = "3.2.1"
+  val freestyle = "0.1.1"
   val googleApiClient = "1.20.0"
   val hasher = "1.2.0"
   val http4s = "0.15.0a"


### PR DESCRIPTION
We migrate the Shared Collection service, from the `services` module, to use freestyle. This involves some conversions between `FreeS.Par` and the local `NineCardsService` types.